### PR TITLE
Migrate to xdg and use chemzoi

### DIFF
--- a/.config/README.md
+++ b/.config/README.md
@@ -1,0 +1,17 @@
+# XDG Base Directory Configuration
+
+This directory follows the XDG Base Directory specification.
+
+## Directory Structure
+
+- `zsh/` - Zsh configuration files
+- `vim/` - Vim configuration files
+- `git/` - Git configuration
+- `less/` - Less pager configuration
+
+## Environment Variables
+
+- `XDG_CONFIG_HOME` - Configuration directory (default: ~/.config)
+- `XDG_DATA_HOME` - Data directory (default: ~/.local/share)
+- `XDG_CACHE_HOME` - Cache directory (default: ~/.cache)
+- `XDG_STATE_HOME` - State directory (default: ~/.local/state)

--- a/.config/chezmoi/chezmoi.toml
+++ b/.config/chezmoi/chezmoi.toml
@@ -1,0 +1,21 @@
+# chezmoi configuration
+
+[data]
+    # Personal information
+    name = "Your Name"
+    email = "your.email@example.com"
+
+[edit]
+    command = "vim"
+
+[git]
+    autoCommit = true
+    autoPush = false
+
+# Use XDG Base Directory specification
+[diff]
+    exclude = ["scripts"]
+
+# Template options
+[template]
+    options = ["missingkey=zero"]

--- a/.config/less/lesskey
+++ b/.config/less/lesskey
@@ -1,0 +1,5 @@
+#command
+\n undo-hilite
+
+# nb: i also wanted <shift-space> to page up but i'm forced to do that via my TERM emulator (iterm2)
+# because of https://unix.stackexchange.com/questions/88579/shift-space-in-less

--- a/.config/readline/inputrc
+++ b/.config/readline/inputrc
@@ -1,0 +1,40 @@
+# Make Tab autocomplete regardless of filename case
+set completion-ignore-case on
+
+# List all matches in case multiple possible completions are possible
+set show-all-if-ambiguous on
+
+# Immediately add a trailing slash when autocompleting symlinks to directories
+set mark-symlinked-directories on
+
+# Use the text that has already been typed as the prefix for searching through
+# commands (i.e. more intelligent Up/Down behavior)
+"\e[B": history-search-forward
+"\e[A": history-search-backward
+
+# Do not autocomplete hidden files unless the pattern explicitly begins with a dot
+set match-hidden-files off
+
+# Show all autocomplete results at once
+set page-completions off
+
+# If there are more than 200 possible completions for a word, ask to show them all
+set completion-query-items 200
+
+# Show extra file information when completing, like `ls -F` does
+set visible-stats on
+
+# Be more intelligent when autocompleting by also looking at the text after
+# the cursor. For example, when the current line is "cd ~/src/mozil", and
+# the cursor is on the "z", pressing Tab will not autocomplete it to "cd
+# ~/src/mozillail", but to "cd ~/src/mozilla". (This is supported by the
+# Readline used by Bash 4.)
+set skip-completed-text on
+
+# Allow UTF-8 input and output, instead of showing stuff like $'\0123\0456'
+set input-meta on
+set output-meta on
+set convert-meta off
+
+# Use Alt/Meta + Delete to delete the preceding word
+"\e[3;3~": kill-word

--- a/.config/vim/vimrc
+++ b/.config/vim/vimrc
@@ -1,0 +1,20 @@
+" XDG Base Directory support for Vim
+set runtimepath^=$XDG_CONFIG_HOME/vim
+set runtimepath+=$XDG_DATA_HOME/vim
+set runtimepath+=$XDG_CONFIG_HOME/vim/after
+
+set packpath^=$XDG_DATA_HOME/vim,$XDG_CONFIG_HOME/vim
+set packpath+=$XDG_CONFIG_HOME/vim/after,$XDG_DATA_HOME/vim/after
+
+let g:netrw_home = $XDG_DATA_HOME."/vim"
+call mkdir($XDG_DATA_HOME."/vim/spell", 'p')
+
+set backupdir=$XDG_CACHE_HOME/vim/backup | call mkdir(&backupdir, 'p')
+set directory=$XDG_CACHE_HOME/vim/swap   | call mkdir(&directory, 'p')
+set undodir=$XDG_CACHE_HOME/vim/undo     | call mkdir(&undodir,   'p')
+set viewdir=$XDG_CACHE_HOME/vim/view     | call mkdir(&viewdir,   'p')
+
+if !has('nvim') | set viminfofile=$XDG_CACHE_HOME/vim/viminfo | endif
+
+" Now source the original vimrc content
+runtime vimrc.orig

--- a/.config/vim/vimrc.orig
+++ b/.config/vim/vimrc.orig
@@ -1,0 +1,325 @@
+" vim:fdm=marker
+
+set nocompatible " be iMproved
+filetype off     " required!
+
+call plug#begin('~/.vim/plugged')
+
+" ColorSchemes
+Plug 'sjl/badwolf'
+Plug 'NLKNguyen/papercolor-theme'
+Plug 'altercation/vim-colors-solarized'
+
+Plug 'bling/vim-airline'
+Plug 'vim-airline/vim-airline-themes'
+
+Plug 'godlygeek/tabular'
+Plug 'kien/ctrlp.vim'
+
+" Gist.vim and it's dependency
+Plug 'mattn/gist-vim' | Plug 'mattn/webapi-vim'
+
+Plug 'scrooloose/nerdtree'
+Plug 'sjl/clam.vim'
+
+" Git Plugin
+Plug 'tpope/vim-fugitive'
+Plug 'bronson/vim-visual-star-search'
+
+Plug 'tpope/vim-eunuch'
+Plug 'tpope/vim-abolish'
+Plug 'tpope/vim-repeat'
+Plug 'tpope/vim-surround'
+Plug 'tpope/vim-unimpaired'
+Plug 'tpope/vim-commentary'
+
+" Emacs bindings for Vim's CLI
+Plug 'bruno-/vim-husk'
+Plug 'mileszs/ack.vim'
+Plug 'wincent/ferret'
+
+Plug 'jiangmiao/auto-pairs'     " AutoPair Brackets
+Plug 'wellle/targets.vim'       " TextObject Extensions
+Plug 'wellle/tmux-complete.vim' " Auto complete across tmux panes
+
+Plug 'jpalardy/vim-slime'
+
+" OS X Bindings
+"" Reveal in finder
+Plug 'henrik/vim-reveal-in-finder'
+Plug 'itspriddle/vim-marked'
+Plug 'zephod/vim-iterm2-navigator'
+
+" Lisps
+Plug 'wlangstroth/vim-racket'
+Plug 'vim-scripts/scribble.vim'
+Plug 'guns/vim-sexp' , { 'for': ['clojure', 'scheme']  }
+Plug 'tpope/vim-sexp-mappings-for-regular-people', { 'for': ['clojure', 'scheme']  }
+
+" vim-scripts repos
+Plug 'vim-scripts/L9'
+Plug 'csexton/trailertrash.vim'
+
+" Background vim compile
+Plug 'tpope/vim-dispatch'
+
+" BufferList plugin
+Plug 'jeetsukumaran/vim-buffergator'
+
+" Easy-Motion disabled for vim-smalls
+Plug 'Lokaltog/vim-easymotion'
+
+" ExtractLinks
+Plug 'vim-scripts/ingo-library' | Plug 'vim-scripts/PatternsOnText' | Plug 'vim-scripts/ExtractMatches' | Plug 'vim-scripts/ExtractLinks'
+
+" Transpose Tabular data
+Plug 'salsifis/vim-transpose'
+
+call plug#end()
+
+" leader to <SPACE> <-- godsend
+let mapleader = " "
+
+" color scheme
+syntax enable
+let g:solarized_termcolors=256
+let g:rehash256 = 1
+set t_Co=256
+" let g:airline_theme='solarized'
+set bg=dark
+" colorscheme solarized
+colorscheme badwolf
+" colorscheme PaperColor
+" let g:airline_theme='PaperColor'
+
+" Keep this below the colorschemes
+filetype plugin indent on     " required!
+
+" Vim EasyMotion trigger
+let g:EasyMotion_leader_key = '<Leader><Leader>'
+nmap <silent> <C-s> <Plug>(easymotion-w)
+" EasyMotion Highlight
+hi link EasyMotionTarget ErrorMsg
+hi link EasyMotionShade  Comment
+
+nnoremap <Leader>e :Reveal<CR>
+
+" exchange vim
+nmap cx <Plug>(Exchange)
+vmap cx <Plug>(Exchange)
+nmap cC <Plug>(ExchangeClear)
+vmap cX <Plug>(ExchangeLine)
+nmap cX <Plug>(ExchangeLine)
+
+" Treat .hql files as SQL for syntax highlighting
+au BufNewFile,BufRead *.hql set filetype=sql
+
+" Tabs
+set tabstop=2
+set shiftwidth=2
+set expandtab
+set autoindent
+set backspace=indent,eol,start
+set complete-=i
+set showmatch
+set smarttab
+
+set nrformats-=octal
+set shiftround
+
+" timeout fixes
+" set esckeys
+set ttimeoutlen=10
+augroup FastEscape
+    autocmd!
+    au InsertEnter * set timeoutlen=0
+    au InsertLeave * set timeoutlen=1000
+augroup END
+
+" incremental search
+set incsearch
+
+" NerdTreeToggle
+nnoremap <silent> <Leader>n :NERDTreeToggle<CR>
+
+" C+hjkl instead of needing to use c+w
+nnoremap <C-h> <C-w>h
+nnoremap <C-j> <C-w>j
+nnoremap <C-k> <C-w>k
+nnoremap <C-l> <C-w>l
+
+" smart column moving
+nnoremap j gj
+nnoremap k gk
+nnoremap gk k
+nnoremap gj j
+
+" iTerm2 is remapping S-Space to C-U
+" toggle hold with <S-Space> if over a fold
+nnoremap <C-U> za
+
+" vimrc tweaking -- from 'Instantly Better Vim'
+nnoremap <silent> cv :sp $MYVIMRC<CR>
+
+augroup VimReload
+  autocmd!
+  autocmd BufWritePost $MYVIMRC source $MYVIMRC
+augroup END
+
+" persistent undo
+if !isdirectory($HOME . "/.vim/undo")
+    call mkdir($HOME . "/.vim/undo", "p")
+endif
+set undofile
+set undodir=$HOME/.vim/undo " directory needs to exist(!)
+set undolevels=10000
+set undoreload=10000        " number of lines to save for undo
+
+" visual mode defaults
+set virtualedit=block
+
+" case and searching
+set smartcase ignorecase
+set incsearch
+set hlsearch
+
+" clear search with ENTER
+nnoremap <CR> :nohlsearch<CR>
+
+" search and replace shortcut
+nnoremap S :%s//g<LEFT><LEFT>
+vnoremap S :s//g<LEFT><LEFT>
+
+" toggle line wrapping
+set nowrap
+
+" toggle list chars
+set nolist
+
+" TrailerTrash Trim
+" nnoremap cot :Trim<bar>w<CR>
+nnoremap <Leader>t :TrailerTrim<CR>
+
+" set current file's directory as the vim directory
+nnoremap <Leader>c :cd %:p:h<CR>
+nnoremap <Leader>r :NERDTreeFind<cr>
+
+" line numbers
+" all surrounding lines have relative numbers
+" set relativenumber
+" current line has absolute numbering
+" set number
+
+" swap colon and semicolon
+noremap ; :
+noremap : ;
+
+" swap visual and block visual mode
+noremap v <c-v>
+noremap <c-v> v
+
+"make search results appear in middle of screen
+nnoremap n nzz
+nnoremap N Nzz
+nnoremap * *zz
+nnoremap # #zz
+nnoremap g* g*zz
+nnoremap g# g#zz
+
+" not sure what this does anymore, should investigate
+set formatoptions+=rco
+
+" always display status line
+set laststatus=2
+set ruler
+set showcmd
+set wildmenu
+" Show list of completions, and complete as much as possible, then iterate full completions
+set wildmode=list:longest,full
+
+" scrolloff f
+if !&scrolloff
+  set scrolloff=1
+endif
+if !&sidescrolloff
+  set sidescrolloff=5
+endif
+set display+=lastline
+
+" Use the same symbols as TextMate for tabstops and EOLs
+set listchars=trail:·,precedes:«,extends:»,tab:▸\ ,eol:¬
+
+" Break character
+set showbreak=↪
+
+" font scheme
+set guifont=Hack:h13
+" set guifont=Inconsolata:h16
+" set guifont=Monaco:h16
+
+" splits open to bottom and right
+set splitright
+set splitbelow
+
+" clam in vim
+nnoremap ! :Clam<space>
+vnoremap ! :ClamVisual<space>
+
+" nerdtree left
+let g:NERDTreeWinPos = "left"
+
+" ctrl-p mappings
+let g:ctrlp_map = '<c-p>'
+let g:ctrlp_cmd = 'CtrlP'
+" nnoremap <C-P>. :CtrlPTag<cr>
+let g:ctrlp_working_path_mode = 'ra'
+" let g:ctrlp_user_command = ['.git', 'cd %s && git ls-files']
+let g:ctrlp_user_command = ['.git', 'cd %s && git ls-files . -co --exclude-standard']
+
+"====[ I'm sick of typing :%s/.../.../g ]=======
+nnoremap S :%s//g<LEFT><LEFT>
+vnoremap S :s//g<LEFT><LEFT>
+
+" Visually select last edited/pasted text
+" http://vimcasts.org/episodes/bubbling-text/
+nnoremap gp `[v`]
+
+" Run quick scripts
+" Adapted from: http://oinksoft.com/blog/view/6/
+let ft_stdout_mappings = {
+      \'bash':        'bash',
+      \'javascript':  'node',
+      \'nodejs':      'node',
+      \'perl':        'perl',
+      \'php':         'php',
+      \'python':      'python',
+      \'ruby':        'ruby',
+      \'sh':          'sh',
+      \}
+let ft_execute_mappings = {
+      \'c': 'gcc -o %:r -Wall -std=c99 % && ./%:r',
+      \'md': 'open -app Marked2.app %',
+      \'markdown': 'open -app Marked2.app %',
+      \'applescript': 'osascript %',
+      \}
+
+for ft_name in keys(ft_stdout_mappings)
+  execute 'autocmd Filetype ' . ft_name . ' nnoremap <buffer> <C-e> :Dispatch '
+          \. ft_stdout_mappings[ft_name] . ' % <CR>'
+endfor
+
+for ft_name in keys(ft_execute_mappings)
+  execute 'autocmd FileType ' . ft_name
+          \. ' nnoremap <buffer> <C-e> :Dispatch '
+          \. ft_execute_mappings[ft_name] . '<CR>'
+endfor
+
+nnoremap <Leader>pi :PlugInstall<CR>
+nnoremap <Leader>pu :PlugUpdate!<CR>
+nnoremap <Leader>pc :PlugClean<CR>
+
+" IndentGuides
+nnoremap coi :IndentGuidesToggle<CR>
+let g:indent_guides_start_level=1
+let g:indent_guides_guide_size=1
+

--- a/.config/zsh/.zlogin
+++ b/.config/zsh/.zlogin
@@ -1,0 +1,12 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+# Execute code that does not affect the current session in the background.
+{
+  # Compile the completion dump to increase startup speed.
+  zcompdump="${ZDOTDIR:-$HOME}/.zcompdump"
+  if [[ -s "$zcompdump" && (! -s "${zcompdump}.zwc" || "$zcompdump" -nt "${zcompdump}.zwc") ]]; then
+    zcompile "$zcompdump"
+  fi
+} &!

--- a/.config/zsh/.zprofile
+++ b/.config/zsh/.zprofile
@@ -1,0 +1,69 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+# Locale Settings
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+
+# NB: need to run `autoload zkbd && zkbd` to setup keycode file being sourced below
+# ideally, only need to run ^ once when setting up a new computer.
+# source ~/.zkbd/$TERM-${${DISPLAY:t}:-$VENDOR-$OSTYPE}
+
+# `less` configuration
+# -F: automatically exit if the entire file can be displayed on the first screen.
+# -X: disable termcap (de)/init. (stops less clearing the screen).
+# -R: color it up.
+# -j.5: make search results appear in the center of the screen (.5 = 50%).
+export LESS="-FXRj.5"
+export LESSCHARSET=utf-8
+export PAGER=less
+
+# EDITOR preferences
+export EDITOR="vim" # as god intended
+bindkey -v          # vim bindings for zsh
+
+# Export existing paths.
+typeset -gxU path PATH
+typeset -gxU fpath FPATH
+typeset -gxU manpath MANPATH
+
+# github base path (useful for `ghc`)
+export GHPATH=$HOME/code/gocode/src/github.com
+export DOTFILES=$HOME/dotfiles
+
+# Multiple installs of go using https://dave.cheney.net/2014/04/20/how-to-install-multiple-versions-of-go
+# GOBASE=/Users/rungta/code/go1.17.3/bin
+export GOPATH=$HOME/code/gocode
+
+# Enable XDG for `ghcup`, via https://www.haskell.org/ghcup/guide/
+export GHCUP_USE_XDG_DIRS=1
+
+# PATH(s), relies on zsh magic (path == $PATH but in array form and sync'd)
+path=(
+  $HOME/bin
+  $HOME/.local/bin
+  /opt/homebrew/{bin,sbin}
+  $GOPATH/bin
+  /opt/homebrew/opt/python@3.11/libexec/bin
+  $HOME/code/FlameGraph
+  $HOME/code/gocode/src/code.uber.internal/go-code/bin
+  $HOME/code/gocode/src/code.uber.internal/go-code/tools
+  $HOME/.cargo/bin
+  /usr/{sbin,bin}
+  /{sbin,bin}
+  /usr/local/{sbin,bin}
+  $path
+)
+path=($^path(N-/))
+
+# Set the list of directories that man searches for manuals.
+manpath=(
+  /usr/local/man
+  /usr/local/share/man
+  /usr/share/man
+)
+manpath=($^manpath(N-/))
+
+# Added by OrbStack: command-line tools and integration
+source ~/.orbstack/shell/init.zsh 2>/dev/null || :

--- a/.config/zsh/.zshenv
+++ b/.config/zsh/.zshenv
@@ -1,0 +1,17 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+# XDG Base Directory specification
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+
+# Set ZDOTDIR to use XDG_CONFIG_HOME
+export ZDOTDIR="${XDG_CONFIG_HOME}/zsh"
+
+# Ensure that a non-login, non-interactive shell has a defined environment.
+if [[ ( "$SHLVL" -eq 1 && ! -o LOGIN ) && -s "${ZDOTDIR}/.zprofile" ]]; then
+  source "${ZDOTDIR}/.zprofile"
+fi

--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -1,0 +1,38 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+export SYSTEM=$(uname -s)
+export ZSHCONFIG=$DOTFILES
+
+# Update to use XDG-compliant path for init.sh
+ZSH_INIT=${XDG_CONFIG_HOME}/zsh/init.sh
+if [[ -s ${ZSH_INIT} ]]; then
+    source ${ZSH_INIT}
+else
+    echo "Could not find the init script ${ZSH_INIT}"
+fi
+
+# Compinit optimization - only regenerate dump once per day
+# https://gist.github.com/ctechols/ca1035271ad134841284
+# https://carlosbecker.com/posts/speeding-up-zsh
+#
+# Note: This is now handled by zinit with zpcompinit in zinit-init.zsh
+# Commenting out to avoid duplicate initialization
+#
+# autoload -Uz compinit
+# case $SYSTEM in
+#   Darwin)
+#     if [ $(date +'%j') != $(/usr/bin/stat -f '%Sm' -t '%j' ${ZDOTDIR:-$HOME}/.zcompdump) ]; then
+#       compinit;
+#     else
+#       compinit -C;
+#     fi
+#     ;;
+#   Linux)
+#     # not yet match GNU & BSD stat
+#   ;;
+# esac
+
+# Added by Windsurf
+export PATH="/Users/prateek/.codeium/windsurf/bin:$PATH"

--- a/.config/zsh/autoload/autoload_scmpuff_status
+++ b/.config/zsh/autoload/autoload_scmpuff_status
@@ -1,0 +1,6 @@
+function autoload_scmpuff_status() {
+  eval "$(scmpuff init --shell=zsh --aliases=false --wrap=false)"
+  scmpuff_status "$@"
+}
+
+autoload_scmpuff_status "$@"

--- a/.config/zsh/autoload/clip_nocr
+++ b/.config/zsh/autoload/clip_nocr
@@ -1,0 +1,6 @@
+# replace newlines in clipboard with a single space
+function clip_nocr() {
+  pbpaste | tr '\n' ' ' | gsed -e 's/  */ /g' | sponge | pbcopy
+}
+
+clip_nocr "$@"

--- a/.config/zsh/autoload/ghclone
+++ b/.config/zsh/autoload/ghclone
@@ -1,0 +1,23 @@
+# `ghclone`: github-checkout -- quick checkout and directory switcher
+# usage (1) `$ ghclone <github-user>/<github-repo>`
+# usage (2) `$ ghclone github.com/<github-user>/<github-repo>(/.*)?`
+function ghclone() {
+  local ghstub=$(echo $1 | sed -e 's/.*github.com\///g' -e 's/#.*$//g' | cut -d/ -f1,2)
+  local target=$GHPATH/$ghstub
+  if ! [ -d "$target" ]; then
+    dirname=$(dirname $target)
+    mkdir -p $dirname
+    git clone git@github.com:${ghstub}.git $target
+  fi
+  cd $target
+  # check directory git status
+  if [ -n "$(git status --porcelain)" ]; then
+    echo "WARNING: git status is not clean"
+  else
+    default_branch=$(git remote show origin | grep 'HEAD branch' | cut -d: -f2 | sed -e 's/ //g')
+    git checkout $default_branch
+    git pull origin $default_branch
+  fi
+}
+
+ghclone "$@"

--- a/.config/zsh/autoload/iterm_session_history
+++ b/.config/zsh/autoload/iterm_session_history
@@ -1,0 +1,15 @@
+# iterm_session_history
+
+# return last `num_lines` of iterm2 session history in reverse chronological order
+function iterm_session_history(){
+  local num_lines=1000
+
+  # this location is configured via iTerm2 Preferences |> Profiles |> <Profile> |> Session |> "Automatically log session input to files in"
+  local ITERM_SESSION_HISTORY_LOG_DIR=~/Library/Logs/iterm2-session-logs
+
+  local current_session_id=$(echo $ITERM_SESSION_ID | tr ':' '.')
+  local current_session_file=$(ls $ITERM_SESSION_HISTORY_LOG_DIR | grep $current_session_id | head -n 1)
+  tail -n $num_lines $ITERM_SESSION_HISTORY_LOG_DIR/$current_session_file | tac
+}
+
+iterm_session_history "$@"

--- a/.config/zsh/autoload/j
+++ b/.config/zsh/autoload/j
@@ -1,0 +1,14 @@
+# TODO: use aliases to jump to common directories quickly.
+# For my needs, it'll suffice (and let me avoid avoid j/z/fasd).
+
+# autojump sourcing
+# h/t https://kevin.burke.dev/kevin/profiling-zsh-startup-time/ for the lazy-loading trick.
+function j() {
+    (( $+commands[brew] )) && {
+        local pfx=$(brew --prefix)
+        [[ -f "$pfx/etc/autojump.sh" ]] && . "$pfx/etc/autojump.sh"
+        j "$@"
+    }
+}
+
+j "$@"

--- a/.config/zsh/autoload/jira
+++ b/.config/zsh/autoload/jira
@@ -1,0 +1,33 @@
+# relies on https://github.com/ankitpokhrel/jira-cli being installed
+
+# jira interactions
+function force_update_jira_token() {
+  # ensure we have a ussh cert
+  usshcertstatus -quiet_mode
+  local rc=$?
+  if [ $rc -ne 0 ]; then
+    echo "no ussh token found, aborting!"
+    return 1
+  fi
+
+  # get t3 USSO token via ussh cert
+  export JIRA_API_TOKEN=$(usso -ussh t3 -print 2>/dev/null)
+  return 0
+}
+
+function jira() {
+  # first check if we already have a JIRA_API_TOKEN set
+  if [[ ! -n ${JIRA_API_TOKEN} ]]; then
+    force_update_jira_token &>/dev/null
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+      echo "JIRA_API_TOKEN not set, unable to retrieve via usso."
+      return 1
+    fi
+  fi
+
+  # need to override LESS
+  LESS="-Rj.5" command jira "$@"
+}
+
+jira "$@"

--- a/.config/zsh/autoload/list_completions
+++ b/.config/zsh/autoload/list_completions
@@ -1,0 +1,12 @@
+# adapted from https://stackoverflow.com/questions/40010848/how-to-list-all-zsh-autocompletions
+function list_completions() {
+  for command completion in ${(kv)_comps:#-*(-|-,*)}
+  do
+    printf "%-32s %s\n" $command $completion
+  done | sort
+}
+
+# also useful:
+# https://unix.stackexchange.com/questions/509869/how-to-look-up-zsh-completion-definitions
+
+list_completions "$@"

--- a/.config/zsh/autoload/path
+++ b/.config/zsh/autoload/path
@@ -1,0 +1,11 @@
+# -------------------------------------------------------------------
+# display a neatly formatted PATH content with colors
+# -------------------------------------------------------------------
+
+echo $PATH | tr ":" "\n" | \
+awk "{ sub(\"/usr\",   \"$fg_no_bold[green]/usr$reset_color\"); \
+			sub(\"/bin\",   \"$fg_no_bold[blue]/bin$reset_color\"); \
+			sub(\"/opt\",   \"$fg_no_bold[cyan]/opt$reset_color\"); \
+			sub(\"/sbin\",  \"$fg_no_bold[magenta]/sbin$reset_color\"); \
+			sub(\"/local\", \"$fg_no_bold[yellow]/local$reset_color\"); \
+			print }"

--- a/.config/zsh/autoload/sshrc
+++ b/.config/zsh/autoload/sshrc
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# taken from https://github.com/cdown/sshrc
+
+function sshrc() {
+    local SSHHOME=${SSHHOME:=~}
+    if [ -f $SSHHOME/.sshrc ]; then
+        local files=.sshrc
+        if [ -d $SSHHOME/.sshrc.d ]; then
+            files="$files .sshrc.d"
+        fi
+        SIZE=$(tar cfz - -h -C $SSHHOME $files | wc -c)
+        if [ $SIZE -gt 65536 ]; then
+            echo >&2 $'.sshrc.d and .sshrc files must be less than 64kb\ncurrent size: '$SIZE' bytes'
+            exit 1
+        fi
+        if [ -z "$CMDARG" -a ! -e ~/.sshrc.d/.hushlogin ]; then
+            WELCOME_MSG="
+                if [ ! -e ~/.hushlogin ]; then
+                    if [ -e /etc/motd ]; then cat /etc/motd; fi
+                    if [ -e /etc/update-motd.d ]; then run-parts /etc/update-motd.d/ 2>/dev/null; fi
+                    last -F \$USER 2>/dev/null | grep -v 'still logged in' | head -n1 | awk '{print \"Last login:\",\$4,\$5,\$6,\$7,\$8,\"from\",\$3;}'
+                fi
+                "
+        else
+            WELCOME_MSG=""
+        fi
+        ssh -t "$DOMAIN" $SSHARGS "
+            command -v openssl >/dev/null 2>&1 || { echo >&2 \"sshrc requires openssl to be installed on the server, but it's not. Aborting.\"; exit 1; }
+            $WELCOME_MSG
+            export SSHHOME=\$(mktemp -d -t .$(whoami).sshrc.XXXX)
+            export SSHRCCLEANUP=\$SSHHOME
+            trap \"rm -rf \$SSHRCCLEANUP; exit\" 0
+            echo $'"$(cat "$0" | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d > \$SSHHOME/sshrc
+            chmod +x \$SSHHOME/sshrc
+
+            echo $'"$( cat << 'EOF' | openssl enc -base64
+                if [ -r /etc/profile ]; then source /etc/profile; fi
+                if [ -r ~/.bash_profile ]; then source ~/.bash_profile
+                elif [ -r ~/.bash_login ]; then source ~/.bash_login
+                elif [ -r ~/.profile ]; then source ~/.profile
+                fi
+                export PATH=$PATH:$SSHHOME
+                source $SSHHOME/.sshrc;
+EOF
+                )"' | tr -s ' ' $'\n' | openssl enc -base64 -d > \$SSHHOME/sshrc.bashrc
+
+            echo $'"$( cat << 'EOF' | openssl enc -base64
+#!/usr/bin/env bash
+                exec bash --rcfile <(echo '
+                [ -r /etc/profile ] && source /etc/profile
+                if [ -r ~/.bash_profile ]; then source ~/.bash_profile
+                elif [ -r ~/.bash_login ]; then source ~/.bash_login
+                elif [ -r ~/.profile ]; then source ~/.profile
+                fi
+                source '$SSHHOME'/.sshrc;
+                export PATH=$PATH:'$SSHHOME'
+                ') "$@"
+EOF
+                )"' | tr -s ' ' $'\n' | openssl enc -base64 -d > \$SSHHOME/bashsshrc
+            chmod +x \$SSHHOME/bashsshrc
+
+            echo $'"$(tar czf - -h -C $SSHHOME $files | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d | tar mxzf - -C \$SSHHOME
+            export SSHHOME=\$SSHHOME
+            echo \"$CMDARG\" >> \$SSHHOME/sshrc.bashrc
+            bash --rcfile \$SSHHOME/sshrc.bashrc
+            "
+    else
+        echo "No such file: $SSHHOME/.sshrc" >&2
+        exit 1
+    fi
+}
+
+function sshrc_parse() {
+  while [[ -n $1 ]]; do
+    case $1 in
+      -b | -c | -D | -E | -e | -F | -I | -i | -J | -L | -l | -m | -O | -o | -p | -Q | -R | -S | -W | -w )
+        SSHARGS="$SSHARGS $1 $2"; shift ;;
+      -* )
+        SSHARGS="$SSHARGS $1" ;;
+      *)
+        if [ -z "$DOMAIN" ]; then
+         DOMAIN="$1"
+        else
+          local SEMICOLON=$([[ "$@" = *[![:space:]]* ]] && echo '; ')
+          CMDARG="$@$SEMICOLON exit"
+          return;
+        fi
+        ;;
+    esac
+    shift
+  done
+  if [ -z $DOMAIN ]; then
+    ssh $SSHARGS; exit 1;
+  fi
+}
+
+command -v openssl >/dev/null 2>&1 || { echo >&2 "sshrc requires openssl to be installed locally, but it's not. Aborting."; exit 1; }
+sshrc_parse "$@"
+sshrc

--- a/.config/zsh/extra/fzf.zsh
+++ b/.config/zsh/extra/fzf.zsh
@@ -1,0 +1,55 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+# make fzf ctrl-r behave like zaw, via https://github.com/fsouza/dotfiles/blob/main/extra/fzf
+function _rebind_ctrl-r {
+	function fzf-history-widget {
+		local selected num
+		setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases 2> /dev/null
+		selected=( $(fc -rl 1 | perl -ne 'print if !$seen{($_ =~ s/^\s*[0-9]+\s+//r)}++' |
+			FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} ${FZF_DEFAULT_OPTS} -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort --expect=ctrl-e $FZF_CTRL_R_OPTS --query=${(qqq)LBUFFER} +m" $(__fzfcmd)) )
+		local ret=$?
+		if [ -n "${selected}" ]; then
+			local accept=0
+			if [[ $selected[1] == ctrl-e ]]; then
+				accept=1
+				shift selected
+			fi
+			num=$selected[1]
+			if [ -n "${num}" ]; then
+				zle vi-fetch-history -n $num
+				[[ $accept = 0 ]] && zle accept-line
+			fi
+		fi
+		zle reset-prompt
+		return $ret
+	}
+	zle     -N   fzf-history-widget
+	bindkey '^R' fzf-history-widget
+}
+
+function _setup_fzf {
+	# ensure fzf completion and key-bindings is configured.
+	if [[ -v HOMEBREW_PREFIX ]] && [ -d ${HOMEBREW_PREFIX}/opt/fzf ]; then
+		[[ $- == *i* ]] && source ${HOMEBREW_PREFIX}/opt/fzf/shell/completion.zsh 2> /dev/null
+
+		# very opinionated FZF style opts.
+		export FZF_DEFAULT_OPTS="
+			--bind=ctrl-e:accept
+			--cycle
+			--height=40% --layout=reverse --border=none --info=hidden --margin=0% --marker='*' --history-size=${HISTSIZE}
+			--color=dark
+			--color=fg:-1,bg:-1,hl:#c678dd,fg+:#ffffff,bg+:#252931,hl+:#d858fe
+			--color=info:#98c379,prompt:#61afef,pointer:#be5046,marker:#e5c07b,spinner:#61afef,header:#61afef
+		"
+		export FZF_DEFAULT_COMMAND="fd --type f --hidden -E '.git' -E '.hg'"
+
+		source ${HOMEBREW_PREFIX}/opt/fzf/shell/key-bindings.zsh
+		_rebind_ctrl-r
+	fi
+}
+
+if command -v fzf &>/dev/null; then
+	_setup_fzf
+fi

--- a/.config/zsh/init.sh
+++ b/.config/zsh/init.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+#-----------------------------------------------------
+# Cache homebrew prefix early (before plugins need it)
+#-----------------------------------------------------
+if [[ -z ${HOMEBREW_PREFIX:-} ]] && command -v brew >/dev/null 2>&1; then
+    export HOMEBREW_PREFIX="$(brew --prefix)"
+fi
+
+#-----------------------------------------------------
+# bootstrap zinit script
+#-----------------------------------------------------
+ZINIT_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/zinit/zinit.git"
+if [[ ! -d "$ZINIT_HOME" ]]; then
+    mkdir -p "$(dirname $ZINIT_HOME)"
+    git clone https://github.com/zdharma-continuum/zinit.git "$ZINIT_HOME"
+fi
+source "$ZINIT_HOME/zinit.zsh"
+
+#-----------------------------------------------------
+# load zinit plugins
+#-----------------------------------------------------
+source "${XDG_CONFIG_HOME}/zsh/zinit-init.zsh"
+
+#-----------------------------------------------------
+# Setting autoloaded functions
+#-----------------------------------------------------
+zsh_fns=${XDG_CONFIG_HOME}/zsh/autoload
+fpath=($zsh_fns $fpath)
+if [[ -d "$zsh_fns" ]]; then
+    for func in $zsh_fns/*; do
+        autoload -Uz ${func:t}
+    done
+fi
+unset zsh_fns
+
+#-----------------------------------------------------
+# Load all utility scripts
+#-----------------------------------------------------
+zsh_libs=${XDG_CONFIG_HOME}/zsh/lib
+if [[ -d "$zsh_libs" ]]; then
+   for file in $zsh_libs/*.zsh; do
+      source $file
+   done
+fi
+unset zsh_libs
+
+#-----------------------------------------------------
+# Load all extras from ${XDG_CONFIG_HOME}/zsh/extra/*.zsh
+# NB: these are to be loaded after everything else,
+# as they overwrite behaviour of stuff.
+#-----------------------------------------------------
+extras=${XDG_CONFIG_HOME}/zsh/extra
+if [[ -d "$extras" ]]; then
+   for file in $extras/*.zsh; do
+      source $file
+   done
+fi
+unset extras
+
+# Set PATH for macOS (only for interactive login shells)
+if [[ -x /bin/launchctl && -o interactive && -o login ]]; then
+    /bin/launchctl setenv PATH "$PATH"
+fi

--- a/.config/zsh/lib/alias.zsh
+++ b/.config/zsh/lib/alias.zsh
@@ -1,0 +1,84 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+# git aliases
+alias gs='autoload_scmpuff_status'
+alias ga="git add"
+alias gd="git diff"
+alias gb="git branch"
+alias gca="git commit -a"
+alias gl="git gl"
+alias gco="git checkout"
+alias gp='git pull origin $(git rev-parse --abbrev-ref HEAD)'
+alias gpo='git pull origin $(git rev-parse --abbrev-ref HEAD)'
+alias push='git push origin $(git rev-parse --abbrev-ref HEAD)'
+alias pushf='git push origin $(git rev-parse --abbrev-ref HEAD) --force'
+alias pull='git pull'
+alias grim='git rebase -i $(git symbolic-ref refs/remotes/origin/HEAD | sed "s@^refs/remotes/origin/@@")'
+alias grimb='BASE=$(git symbolic-ref refs/remotes/origin/HEAD | sed "s@^refs/remotes/origin/@@") && git rebase -i $(git merge-base $BASE HEAD)'
+
+# use fzf to autocomplete git branches
+gcf() {
+    git checkout $(git branch | fzf)
+}
+
+# use fzf to delete branches, allow multiple selections
+gbd() {
+    # use TAB/S-TAB to select multiple branches
+    git branch -D $(git branch | fzf -m)
+}
+
+# adapted from https://github.com/Phantas0s/.dotfiles/blob/master/zsh/scripts_fzf.zsh
+# git log browser with FZF
+fgl() {
+  git log --graph --color=always \
+      --format="%C(auto)%h%d %s %C(black)%C(bold)%cr" "$@" |
+  fzf --ansi --no-sort --reverse --tiebreak=index --bind=ctrl-s:toggle-sort \
+      --bind "ctrl-m:execute:
+                (grep -o '[a-f0-9]\{7\}' | head -1 |
+                xargs -I % sh -c 'git show --color=always % | less -R') << 'FZF-EOF'
+                {}
+FZF-EOF"
+}
+
+# # adapted from: http://stackoverflow.com/questions/14031970/git-push-current-branch-shortcut
+# function gpb()
+# {
+#     if git rev-parse --abbrev-ref --symbolic-full-name @{u} > /dev/null 2>&1; then
+#         git push origin HEAD
+#     else
+#         git push -u origin HEAD
+#     fi
+# }
+
+alias jls="jira issue list"
+# FIXME: alias ssh=sshrc
+
+# Aliases
+alias ls='ls -G'
+alias ll='ls -lhG'
+alias vimd='vim -d'
+alias psef='ps -ef | grep -i'
+alias ps='ps -T'
+# alias cat='bat --style=plain'
+alias grep='egrep --color=auto'
+alias egrep='egrep --color=auto'
+
+## zshrc modification aliases
+alias sz='exec zsh'
+alias ez='code ~/dotfiles'
+alias jz='cd ~/dotfiles'
+
+alias ec='code ~/.claude'
+alias jc='cd ~/.claude'
+
+alias yo='open -a Yoink'
+alias yolo='claude --dangerously-skip-permissions'
+# FIXME: Pipe Aliases
+# alias L=' | less '
+# alias G=' | egrep --color=auto '
+# alias T=' | tail '
+# alias H=' | head '
+# alias W=' | wc -l '
+# alias S=' | sort '

--- a/.config/zsh/lib/completions.zsh
+++ b/.config/zsh/lib/completions.zsh
@@ -1,0 +1,50 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+################################################################################
+# https://github.com/sorin-ionescu/prezto/blob/master/modules/completion/init.zsh
+# https://github.com/robbyrussell/oh-my-zsh/blob/master/lib/completion.zsh
+# https://github.com/zimfw/zimfw/blob/master/modules/completion/init.zsh
+# https://grml.org/zsh/zsh-lovers.html
+################################################################################
+
+unsetopt menu_complete     # do not autoselect the first completion entry
+unsetopt flow_control      # disable start/stop characters in shell editor
+unsetopt case_glob         # makes globbing (filename generation) case-sensitive
+
+setopt no_beep             # no beeps
+setopt multios             # tee/cat automatically
+setopt always_to_end       # move cursor to the end of a completed word
+setopt auto_menu           # show completion menu on a successive tab press
+setopt complete_in_word    # complete from both ends of a word
+setopt no_complete_aliases # autoexapnd aliases
+setopt nolistambiguous     # one tab for completion
+
+# zsh completion
+zstyle ':completion:*' menu select
+compctl -g '*(/)' rmdir dircmp j
+compctl -g '*(-/)' cd chdir dirs pushd j
+
+## colorize completions
+zstyle ':completion:*' list-colors ''
+zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
+
+# [ -f ~/.fzf-tab/fzf-tab.plugin.zsh ] && source ~/.fzf-tab/fzf-tab.plugin.zsh
+# zstyle ':fzf-tab:*' continuous-trigger '/'
+# zstyle ':fzf-tab:*' fzf-bindings 'ctrl-e:accept'
+# zstyle ':fzf-tab:*' accept-line enter
+
+# globalias() {
+#    if [[ $LBUFFER =~ ' [A-Z0-9]+$' ]]; then
+#      zle _expand_alias
+#      zle expand-word
+#    fi
+#    zle self-insert
+# }
+#
+# zle -N globalias
+#
+# bindkey " " globalias
+# bindkey "^ " magic-space           # control-space to bypass completion
+# bindkey -M isearch " " magic-space # normal space during searches

--- a/.config/zsh/lib/dircolors-custom
+++ b/.config/zsh/lib/dircolors-custom
@@ -1,0 +1,227 @@
+# vim: ft=dircolors:fdm=marker:et:sw=2:
+
+# See:
+#		https://unix.stackexchange.com/a/94306/27109
+#		"The format for 256 color escape codes is 38;5;colorN for foreground colors
+#   and 48;5;colorN for background colors."
+#
+#   https://github.com/trapd00r/LS_COLORS
+#		http://linux-sxs.org/housekeeping/lscolors.html
+#
+# Needs dircolors/gdircolors from GNU coreutils
+# brew info coreutils
+
+DIR 		01;34 					# directory
+LINK 		target
+SOCK 		01;35 					# socket
+MISSING 	00
+SETUID 		37;41
+SETGID 		30;43
+CAPABILITY 	30;41
+
+
+*README               38;5;220;1
+*README.rst           38;5;220;1
+*LICENSE              38;5;220;1
+*COPYING              38;5;220;1
+*INSTALL              38;5;220;1
+*COPYRIGHT            38;5;220;1
+*AUTHORS              38;5;220;1
+*HISTORY              38;5;220;1
+*CONTRIBUTORS         38;5;220;1
+*PATENTS              38;5;220;1
+*VERSION              38;5;220;1
+*NOTICE               38;5;220;1
+*CHANGES              38;5;220;1
+
+
+.log                  38;5;190
+.txt                  38;5;253
+
+# markup {{{2
+.info                 38;5;184
+.markdown             38;5;184
+.md                   38;5;184
+.mmd                  38;5;184
+
+# docs, images
+
+.chm                  38;5;151
+.djvu                 38;5;141
+.pdf                  38;5;141
+.PDF                  38;5;141
+.epub                 38;5;131
+.doc                  38;5;111
+.docx                 38;5;111
+.eps                  38;5;111
+.ps                   38;5;111
+.rtf                  38;5;111
+.pps                  38;5;166
+.ppt                  38;5;166
+.pptx                 38;5;166
+.xls                  38;5;112
+.xlsx                 38;5;112
+.xltx                 38;5;73
+.jpeg                 38;5;87
+.JPG                  38;5;87
+.jpg                  38;5;87
+
+
+# version control {{{2
+.git                  38;5;197
+.gitignore            38;5;240
+.gitattributes        38;5;240
+.gitmodules           38;5;240
+
+# shell {{{2
+.awk                  38;5;170
+.bash                 38;5;171
+.sh                   38;5;172
+.vim                  38;5;173
+*conf                 38;5;174
+*rc                   38;5;175
+.login                38;5;176
+.logout               38;5;177
+.zsh                  38;5;180
+
+
+# python
+.py                   38;5;41
+
+# perl
+.pl                   38;5;208
+.PL                   38;5;160
+
+# SQL
+.msql                 38;5;222
+.mysql                38;5;222
+.pgsql                38;5;222
+.sql                  38;5;222
+.sqlite               38;5;60
+
+# Python
+.py                   38;5;41
+.pyc                  38;5;240
+
+# Web
+.js                   38;5;074
+.css                  38;5;125
+.less                 38;5;125
+.sass                 38;5;125
+.scss                 38;5;125
+.htm                  38;5;125
+.html                 38;5;125
+.json                 38;5;178
+.xml                  38;5;178
+.yml                  38;5;178
+.php                  38;5;81
+.coffee               38;5;074
+.htaccess             38;5;230
+
+#   CakePHP view scripts and helpers
+.ctp                  38;5;81
+#   Twig template engine
+.twig                 38;5;81
+
+
+# JAVA
+.java                 38;5;074
+.jsp                  38;5;074
+
+# Build stuff {{{2
+*Dockerfile           38;5;155
+.dockerignore         38;5;240
+*Makefile             38;5;155
+*Makefile             38;5;155
+*MANIFEST             38;5;243
+
+  # packaged apps {{{2
+.apk                  38;5;215
+.jad                  38;5;215
+.jar                  38;5;215
+
+# partition images {{{2
+.dmg                  38;5;124
+.sparseimage          38;5;124
+.dmg                  38;5;215
+
+
+# state files
+.pid                  38;5;248
+.state                38;5;248
+*lockfile             38;5;248
+.lock                 38;5;241
+*composer.lock        38;5;96
+*lock.json            38;5;96
+*components*          38;5;241
+
+# state dumps
+.dump                 38;5;241
+.stackdump            38;5;241
+.zcompdump            38;5;241
+.zwc                  38;5;241
+
+# macOS
+.DS_Store             38;5;239
+.localized            38;5;239
+.CFUserTextEncoding   38;5;239
+
+.md5                  38;5;116
+.properties           38;5;116
+.torrent              38;5;116
+
+# RStudio project file
+.Rproj                38;5;11
+
+# archives {{{1
+.7z                   38;5;210
+.bz2                  38;5;210
+.gz                   38;5;210
+.lzma                 38;5;210
+.rar                  38;5;210
+.tar                  38;5;210
+.tgz                  38;5;210
+.zip                  38;5;210
+
+
+# 0 = default colour
+# 1 = bold
+# 4 = underlined
+# 5 = flashing text
+# 6 = no change
+# 7 = reverse field
+# 8 = black
+# 9 = strikethrough (cool!)
+# 10 - 29= no change
+# 30 = light green
+# 31 = red
+# 32 = green
+# 33 = orange
+# 34 = blue
+# 35 = purple
+# 36 = cyan
+# 37 = grey
+# 38 = underline
+# 39 = no change
+# 40 = black background
+# 41 = red background
+# 42 = green background
+# 43 = orange background
+# 44 = blue background
+# 45 = purple background
+# 46 = cyan background
+# 47 = grey background
+# 90 = dark grey
+# 91 = light red
+# 92 = light green
+# 93 = yellow
+# 94 = light blue
+# 95 = light purple
+# 96 = turquoise
+# 100 = dark grey background
+# 101 = light red background
+# 102 = light green background
+# 103 = yellow background
+# 104 = light blue background
+# 105 = light purple background
+# 106 = turquoise background

--- a/.config/zsh/lib/fzf-tab.zsh
+++ b/.config/zsh/lib/fzf-tab.zsh
@@ -1,0 +1,8 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+# Only use fzf when there are more than 10 candidates
+zstyle ':fzf-tab:*' fzf-min-height 10
+zstyle ':fzf-tab:complete:*' fzf-bindings 'tab:accept'
+zstyle ':fzf-tab:*' switch-group ',' '.'

--- a/.config/zsh/lib/history.zsh
+++ b/.config/zsh/lib/history.zsh
@@ -1,0 +1,20 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+# history options
+# nb: careful updating the history size - it gets expensive
+export HISTFILE=$HOME/.zhistory      # enable history saving on shell exit
+export HISTSIZE=30000                # lines of history to maintain memory
+export SAVEHIST=30000                # lines of history to maintain in history file.
+
+setopt EXTENDED_HISTORY			  # write in the ":start:elapsed;command" format
+setopt HIST_EXPIRE_DUPS_FIRST # allow dups, but expire old ones when I hit HISTSIZE
+setopt HIST_FIND_NO_DUPS      # do not find dups in history
+setopt HIST_IGNORE_ALL_DUPS   # Even if there are commands inbetween commands that are the same, still only save the last one
+setopt HIST_IGNORE_DUPS       # If I type cd and then cd again, only save the last one
+setopt HIST_IGNORE_SPACE      # If a line starts with a space, don't save it.
+setopt HIST_NO_STORE          # dont store invocations of history command.
+setopt HIST_REDUCE_BLANKS     # Pretty    Obvious.  Right?
+setopt HIST_SAVE_NO_DUPS      # dont save dupes
+setopt INC_APPEND_HISTORY     # Write after each command

--- a/.config/zsh/lib/keybind.zsh
+++ b/.config/zsh/lib/keybind.zsh
@@ -1,0 +1,55 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+# make key presses work a lot faster
+# `man keytimeout`: The time the shell waits, in hundredths of seconds,
+# for another key to be pressed when reading bound multi-character sequences.
+KEYTIMEOUT=1
+
+# Enable bracketed paste mode for better paste handling in vi-mode
+autoload -Uz bracketed-paste-magic
+zle -N bracketed-paste bracketed-paste-magic
+
+# Fix paste issues in vi-mode
+zstyle ':bracketed-paste-magic' active-widgets '.self-insert-unmeta'
+
+# map ctrl-space to accept auto-suggestions.
+# color map: https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg
+# usable attributes: https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting
+# export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=252,standout"
+# bindkey '^ ' autosuggest-accept # toggle on ctrl-space
+
+# Who doesn't want home and end to work?
+bindkey -M viins "${key[Home]}" beginning-of-line
+bindkey -M viins "${key[End]}" end-of-line
+
+# ensure alt+arrow keys work
+bindkey "^[^[[D" backward-word
+bindkey "^[^[[C" forward-word
+
+# copy buffer to stack and clear, reload it next time editor starts up
+bindkey -M vicmd 'q' push-line
+
+# vim editing for command line
+autoload -z edit-command-line
+zle -N edit-command-line
+bindkey -M vicmd 'v' edit-command-line
+
+# rerun last command & insert output into current buffer
+zmodload -i zsh/parameter
+insert-last-command-output() {
+  LBUFFER+="$(eval $history[$((HISTCMD-1))])"
+}
+zle -N insert-last-command-output
+bindkey -M viins "^P" insert-last-command-output
+
+# ctrl-u in vi-cmd mode invokes the url_select autoload function
+zle -N url_select
+bindkey -M vicmd "^u" url_select
+
+# TODO: rerurn last command and page output using the bat help pager
+# rerun-last-command-with-bat() {
+#   bathelp='bat --plain --language=help'
+#   $history[$((HISTCMD-1))]
+# }

--- a/.config/zsh/lib/ls_color.zsh
+++ b/.config/zsh/lib/ls_color.zsh
@@ -1,0 +1,10 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+#-----------------------------------------------------
+# Add colors to ls command
+#-----------------------------------------------------
+if [ -f "/usr/local/bin/gdircolors"  ] || [ -f "/usr/bin/gdircolors" ]; then
+	eval $( gdircolors -b ${ZSHCONFIG}/zsh/lib/dircolors-custom )
+fi

--- a/.config/zsh/lib/prompt.zsh
+++ b/.config/zsh/lib/prompt.zsh
@@ -1,0 +1,7 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+
+export PURE_PROMPT_SYMBOL="λ"
+export PURE_PROMPT_VICMD_SYMBOL="Λ"

--- a/.config/zsh/lib/uber.zsh
+++ b/.config/zsh/lib/uber.zsh
@@ -1,0 +1,84 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+export ST=$HOME/code/gocode/src/code.uber.internal/infra/statsdex
+
+alias prod='DOMAIN=system.uberinternal.com; PROD=https://ignored:$(usso -ussh $DOMAIN -print)@$DOMAIN'
+
+list_adhoc() {
+  lzc host list --group=m3-adhoc --format H
+}
+
+ssha() {
+  ssh $(list_adhoc | fzf)
+}
+
+# h/t https://stackoverflow.com/questions/75428312/custom-json-output-formatting-with-jq
+prettify_grafana_json() {
+   jq '.[].datapoints |= "<q>\(tojson)</q>"' | jq -Rr 'sub("<q>(?<s>.*)</q>"; .s)' --sort-keys
+}
+
+# example usage
+# $ resolve_uns uns://phx2/phx2-prod03/us1/statsdex_query/preprod/p-phx2/0:http
+resolve_uns() {
+  uns_path=$1
+  jump_host=$(list_adhoc | head -n 1)
+  ssh ${jump_host} "uns --format compact $uns_path"
+}
+
+# example_usage
+# $ setup_tunnel 8080 $(resolve_uns uns://phx2/phx2-prod03/us1/statsdex_query/preprod/p-phx2/0:http)
+setup_tunnel() {
+  local_port=$1
+  target_hostport=$2
+  jump_host=$(list_adhoc | head -n 1)
+  echo "setting up tunnel on localhost:$local_port to hit $target_hostport via $jump_host"
+  ssh -L ${local_port}:${target_hostport} -N $jump_host
+}
+
+function reposearch() {
+  echo "{\"constraints\": {\"query\": \"$1\"}}"     \
+    | arc call-conduit diffusion.repository.search \
+    | jq -r '.response.data[] | "\(.fields.name) - https://code.uberinternal.com/diffusion/\(.fields.callsign)"'
+}
+
+# functions to make working with arc suck less.
+## WIP quick git commit
+alias wip='git commit -am "fixup! WIP"'
+
+# return the name of the default branch
+function master_or_main() {
+	# via https://stackoverflow.com/questions/28666357/how-to-get-default-git-branch
+	git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
+}
+
+# merges all commits between master..HEAD into a single commit.
+function squash() {
+  GIT_SEQUENCE_EDITOR="sed -i -re '2,\$s/^pick /fixup /'" git rebase -i $(master_or_main)
+}
+
+# merges all commits between master..HEAD with a `fixup!` prefix into the preceding commit.
+function fixup() {
+  GIT_SEQUENCE_EDITOR="sed -i -re '/fixup!/s/^pick /fixup /'" git rebase -i $(master_or_main)
+}
+
+# extract_diff assumes a bunch of shit
+# requires that the differential revision be mentioned in the commit message of the first commit on the branch based off master
+# i.e. no chaining of diffs, no base branch which isn't master, etc.
+function extract_diff() {
+	local base=$(master_or_main)
+  git log --format='%B' -n1 $(git log ${base}..HEAD --oneline | tail -n1 | cut -d ' ' -f 1) | grep 'https://code.uberinternal.com' | sed -e 's@.*\(D[0-9][0-9]*\)$@\1@'
+}
+
+# au is only meant to be used during update, not for creation.
+function au() {
+	local base=$(master_or_main)
+  arc diff --update $(extract_diff) $(git merge-base ${base} HEAD) --message '.' $@
+}
+alias ws='wip && squash'
+alias wsa='wip && squash && au'
+alias wsp='wip && squash && push'
+
+alias wf='wip && fixup'
+alias wff='wip && fixup && farc upload master..'

--- a/.config/zsh/zinit-init.zsh
+++ b/.config/zsh/zinit-init.zsh
@@ -1,0 +1,45 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+# https://zdharma-continuum.github.io/zinit/wiki/GALLERY/
+
+# Load critical items first (prompt needs to be immediate)
+# Load the pure theme, with zsh-async library that's bundled with it
+zinit ice pick"async.zsh" src"pure.zsh" lucid
+zinit light sindresorhus/pure
+
+# fzf is loaded via custom setup in zsh/extra/fzf.zsh
+# Installation handled by Brewfile during bootstrap (not zinit)
+# Removed zinit pack to avoid double loading
+
+# Defer non-critical plugins with turbo mode
+# wait - defers loading (in seconds or with special value)
+# lucid - skip "Loaded" message
+# atinit/atload - commands to run before/after loading
+
+# Completions must load first
+zinit ice wait lucid blockf atpull'zinit creinstall -q .'
+zinit light zsh-users/zsh-completions
+
+# fzf-tab loads after completions with compinit
+zinit ice wait lucid atinit"zpcompinit; zpcdreplay"
+zinit light Aloxaf/fzf-tab
+
+# Syntax highlighting loads last (no compinit needed)
+zinit ice wait lucid
+zinit light zdharma-continuum/fast-syntax-highlighting
+
+# Vi motions can be deferred
+zinit ice wait lucid
+zinit light zsh-vi-more/vi-motions
+
+# direnv loads from binary (deferred since not needed immediately)
+zinit ice wait"1" from"gh-r" as"program" mv"direnv* -> direnv"          \
+    atclone'./direnv hook zsh > zhook.zsh' atpull'%atclone' \
+    pick"direnv" src="zhook.zsh"
+zinit light direnv/direnv
+
+# # ex: commands in vi mode
+# zi ice wait"0" lucid
+# zinit light zsh-vi-more/ex-mode

--- a/.inputrc
+++ b/.inputrc
@@ -1,0 +1,2 @@
+# XDG Base Directory support - redirect to XDG location
+$include ~/.config/readline/inputrc

--- a/.local/share/chezmoi/.chezmoiignore
+++ b/.local/share/chezmoi/.chezmoiignore
@@ -1,0 +1,35 @@
+# Files and directories to ignore
+
+# Documentation
+README.md
+LICENSE
+MIGRATION_GUIDE.md
+
+# Scripts that are not part of the deployed dotfiles
+install-chezmoi.sh
+init-chezmoi.sh
+bootstrap*.sh
+test-*.sh
+
+# Version control
+.git/
+.gitignore
+
+# macOS
+.DS_Store
+
+# Editor files
+*.swp
+*~
+
+# Temporary files
+*.tmp
+*.bak
+
+# Cache directories (these should be created, not synced)
+.cache/
+.local/share/zinit/
+.local/share/vim/
+
+# Other files that shouldn't be managed
+.orbstack/

--- a/.local/share/chezmoi/.gitignore
+++ b/.local/share/chezmoi/.gitignore
@@ -1,0 +1,21 @@
+# Chezmoi state
+.chezmoi.toml.tmpl.lock
+
+# Editor files
+*.swp
+*~
+.*.sw[op]
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.bak
+*.orig
+
+# IDE
+.idea/
+.vscode/
+*.sublime-*

--- a/.local/share/chezmoi/dot_config/chezmoi/chezmoi.toml
+++ b/.local/share/chezmoi/dot_config/chezmoi/chezmoi.toml
@@ -1,0 +1,21 @@
+# chezmoi configuration
+
+[data]
+    # Personal information
+    name = "Your Name"
+    email = "your.email@example.com"
+
+[edit]
+    command = "vim"
+
+[git]
+    autoCommit = true
+    autoPush = false
+
+# Use XDG Base Directory specification
+[diff]
+    exclude = ["scripts"]
+
+# Template options
+[template]
+    options = ["missingkey=zero"]

--- a/.local/share/chezmoi/dot_config/less/lesskey
+++ b/.local/share/chezmoi/dot_config/less/lesskey
@@ -1,0 +1,5 @@
+#command
+\n undo-hilite
+
+# nb: i also wanted <shift-space> to page up but i'm forced to do that via my TERM emulator (iterm2)
+# because of https://unix.stackexchange.com/questions/88579/shift-space-in-less

--- a/.local/share/chezmoi/dot_config/readline/inputrc
+++ b/.local/share/chezmoi/dot_config/readline/inputrc
@@ -1,0 +1,40 @@
+# Make Tab autocomplete regardless of filename case
+set completion-ignore-case on
+
+# List all matches in case multiple possible completions are possible
+set show-all-if-ambiguous on
+
+# Immediately add a trailing slash when autocompleting symlinks to directories
+set mark-symlinked-directories on
+
+# Use the text that has already been typed as the prefix for searching through
+# commands (i.e. more intelligent Up/Down behavior)
+"\e[B": history-search-forward
+"\e[A": history-search-backward
+
+# Do not autocomplete hidden files unless the pattern explicitly begins with a dot
+set match-hidden-files off
+
+# Show all autocomplete results at once
+set page-completions off
+
+# If there are more than 200 possible completions for a word, ask to show them all
+set completion-query-items 200
+
+# Show extra file information when completing, like `ls -F` does
+set visible-stats on
+
+# Be more intelligent when autocompleting by also looking at the text after
+# the cursor. For example, when the current line is "cd ~/src/mozil", and
+# the cursor is on the "z", pressing Tab will not autocomplete it to "cd
+# ~/src/mozillail", but to "cd ~/src/mozilla". (This is supported by the
+# Readline used by Bash 4.)
+set skip-completed-text on
+
+# Allow UTF-8 input and output, instead of showing stuff like $'\0123\0456'
+set input-meta on
+set output-meta on
+set convert-meta off
+
+# Use Alt/Meta + Delete to delete the preceding word
+"\e[3;3~": kill-word

--- a/.local/share/chezmoi/dot_config/vim/vimrc
+++ b/.local/share/chezmoi/dot_config/vim/vimrc
@@ -1,0 +1,20 @@
+" XDG Base Directory support for Vim
+set runtimepath^=$XDG_CONFIG_HOME/vim
+set runtimepath+=$XDG_DATA_HOME/vim
+set runtimepath+=$XDG_CONFIG_HOME/vim/after
+
+set packpath^=$XDG_DATA_HOME/vim,$XDG_CONFIG_HOME/vim
+set packpath+=$XDG_CONFIG_HOME/vim/after,$XDG_DATA_HOME/vim/after
+
+let g:netrw_home = $XDG_DATA_HOME."/vim"
+call mkdir($XDG_DATA_HOME."/vim/spell", 'p')
+
+set backupdir=$XDG_CACHE_HOME/vim/backup | call mkdir(&backupdir, 'p')
+set directory=$XDG_CACHE_HOME/vim/swap   | call mkdir(&directory, 'p')
+set undodir=$XDG_CACHE_HOME/vim/undo     | call mkdir(&undodir,   'p')
+set viewdir=$XDG_CACHE_HOME/vim/view     | call mkdir(&viewdir,   'p')
+
+if !has('nvim') | set viminfofile=$XDG_CACHE_HOME/vim/viminfo | endif
+
+" Now source the original vimrc content
+runtime vimrc.orig

--- a/.local/share/chezmoi/dot_config/zsh/autoload/autoload_scmpuff_status
+++ b/.local/share/chezmoi/dot_config/zsh/autoload/autoload_scmpuff_status
@@ -1,0 +1,6 @@
+function autoload_scmpuff_status() {
+  eval "$(scmpuff init --shell=zsh --aliases=false --wrap=false)"
+  scmpuff_status "$@"
+}
+
+autoload_scmpuff_status "$@"

--- a/.local/share/chezmoi/dot_config/zsh/autoload/clip_nocr
+++ b/.local/share/chezmoi/dot_config/zsh/autoload/clip_nocr
@@ -1,0 +1,6 @@
+# replace newlines in clipboard with a single space
+function clip_nocr() {
+  pbpaste | tr '\n' ' ' | gsed -e 's/  */ /g' | sponge | pbcopy
+}
+
+clip_nocr "$@"

--- a/.local/share/chezmoi/dot_config/zsh/autoload/ghclone
+++ b/.local/share/chezmoi/dot_config/zsh/autoload/ghclone
@@ -1,0 +1,23 @@
+# `ghclone`: github-checkout -- quick checkout and directory switcher
+# usage (1) `$ ghclone <github-user>/<github-repo>`
+# usage (2) `$ ghclone github.com/<github-user>/<github-repo>(/.*)?`
+function ghclone() {
+  local ghstub=$(echo $1 | sed -e 's/.*github.com\///g' -e 's/#.*$//g' | cut -d/ -f1,2)
+  local target=$GHPATH/$ghstub
+  if ! [ -d "$target" ]; then
+    dirname=$(dirname $target)
+    mkdir -p $dirname
+    git clone git@github.com:${ghstub}.git $target
+  fi
+  cd $target
+  # check directory git status
+  if [ -n "$(git status --porcelain)" ]; then
+    echo "WARNING: git status is not clean"
+  else
+    default_branch=$(git remote show origin | grep 'HEAD branch' | cut -d: -f2 | sed -e 's/ //g')
+    git checkout $default_branch
+    git pull origin $default_branch
+  fi
+}
+
+ghclone "$@"

--- a/.local/share/chezmoi/dot_config/zsh/autoload/iterm_session_history
+++ b/.local/share/chezmoi/dot_config/zsh/autoload/iterm_session_history
@@ -1,0 +1,15 @@
+# iterm_session_history
+
+# return last `num_lines` of iterm2 session history in reverse chronological order
+function iterm_session_history(){
+  local num_lines=1000
+
+  # this location is configured via iTerm2 Preferences |> Profiles |> <Profile> |> Session |> "Automatically log session input to files in"
+  local ITERM_SESSION_HISTORY_LOG_DIR=~/Library/Logs/iterm2-session-logs
+
+  local current_session_id=$(echo $ITERM_SESSION_ID | tr ':' '.')
+  local current_session_file=$(ls $ITERM_SESSION_HISTORY_LOG_DIR | grep $current_session_id | head -n 1)
+  tail -n $num_lines $ITERM_SESSION_HISTORY_LOG_DIR/$current_session_file | tac
+}
+
+iterm_session_history "$@"

--- a/.local/share/chezmoi/dot_config/zsh/autoload/j
+++ b/.local/share/chezmoi/dot_config/zsh/autoload/j
@@ -1,0 +1,14 @@
+# TODO: use aliases to jump to common directories quickly.
+# For my needs, it'll suffice (and let me avoid avoid j/z/fasd).
+
+# autojump sourcing
+# h/t https://kevin.burke.dev/kevin/profiling-zsh-startup-time/ for the lazy-loading trick.
+function j() {
+    (( $+commands[brew] )) && {
+        local pfx=$(brew --prefix)
+        [[ -f "$pfx/etc/autojump.sh" ]] && . "$pfx/etc/autojump.sh"
+        j "$@"
+    }
+}
+
+j "$@"

--- a/.local/share/chezmoi/dot_config/zsh/autoload/jira
+++ b/.local/share/chezmoi/dot_config/zsh/autoload/jira
@@ -1,0 +1,33 @@
+# relies on https://github.com/ankitpokhrel/jira-cli being installed
+
+# jira interactions
+function force_update_jira_token() {
+  # ensure we have a ussh cert
+  usshcertstatus -quiet_mode
+  local rc=$?
+  if [ $rc -ne 0 ]; then
+    echo "no ussh token found, aborting!"
+    return 1
+  fi
+
+  # get t3 USSO token via ussh cert
+  export JIRA_API_TOKEN=$(usso -ussh t3 -print 2>/dev/null)
+  return 0
+}
+
+function jira() {
+  # first check if we already have a JIRA_API_TOKEN set
+  if [[ ! -n ${JIRA_API_TOKEN} ]]; then
+    force_update_jira_token &>/dev/null
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+      echo "JIRA_API_TOKEN not set, unable to retrieve via usso."
+      return 1
+    fi
+  fi
+
+  # need to override LESS
+  LESS="-Rj.5" command jira "$@"
+}
+
+jira "$@"

--- a/.local/share/chezmoi/dot_config/zsh/autoload/list_completions
+++ b/.local/share/chezmoi/dot_config/zsh/autoload/list_completions
@@ -1,0 +1,12 @@
+# adapted from https://stackoverflow.com/questions/40010848/how-to-list-all-zsh-autocompletions
+function list_completions() {
+  for command completion in ${(kv)_comps:#-*(-|-,*)}
+  do
+    printf "%-32s %s\n" $command $completion
+  done | sort
+}
+
+# also useful:
+# https://unix.stackexchange.com/questions/509869/how-to-look-up-zsh-completion-definitions
+
+list_completions "$@"

--- a/.local/share/chezmoi/dot_config/zsh/autoload/path
+++ b/.local/share/chezmoi/dot_config/zsh/autoload/path
@@ -1,0 +1,11 @@
+# -------------------------------------------------------------------
+# display a neatly formatted PATH content with colors
+# -------------------------------------------------------------------
+
+echo $PATH | tr ":" "\n" | \
+awk "{ sub(\"/usr\",   \"$fg_no_bold[green]/usr$reset_color\"); \
+			sub(\"/bin\",   \"$fg_no_bold[blue]/bin$reset_color\"); \
+			sub(\"/opt\",   \"$fg_no_bold[cyan]/opt$reset_color\"); \
+			sub(\"/sbin\",  \"$fg_no_bold[magenta]/sbin$reset_color\"); \
+			sub(\"/local\", \"$fg_no_bold[yellow]/local$reset_color\"); \
+			print }"

--- a/.local/share/chezmoi/dot_config/zsh/autoload/sshrc
+++ b/.local/share/chezmoi/dot_config/zsh/autoload/sshrc
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# taken from https://github.com/cdown/sshrc
+
+function sshrc() {
+    local SSHHOME=${SSHHOME:=~}
+    if [ -f $SSHHOME/.sshrc ]; then
+        local files=.sshrc
+        if [ -d $SSHHOME/.sshrc.d ]; then
+            files="$files .sshrc.d"
+        fi
+        SIZE=$(tar cfz - -h -C $SSHHOME $files | wc -c)
+        if [ $SIZE -gt 65536 ]; then
+            echo >&2 $'.sshrc.d and .sshrc files must be less than 64kb\ncurrent size: '$SIZE' bytes'
+            exit 1
+        fi
+        if [ -z "$CMDARG" -a ! -e ~/.sshrc.d/.hushlogin ]; then
+            WELCOME_MSG="
+                if [ ! -e ~/.hushlogin ]; then
+                    if [ -e /etc/motd ]; then cat /etc/motd; fi
+                    if [ -e /etc/update-motd.d ]; then run-parts /etc/update-motd.d/ 2>/dev/null; fi
+                    last -F \$USER 2>/dev/null | grep -v 'still logged in' | head -n1 | awk '{print \"Last login:\",\$4,\$5,\$6,\$7,\$8,\"from\",\$3;}'
+                fi
+                "
+        else
+            WELCOME_MSG=""
+        fi
+        ssh -t "$DOMAIN" $SSHARGS "
+            command -v openssl >/dev/null 2>&1 || { echo >&2 \"sshrc requires openssl to be installed on the server, but it's not. Aborting.\"; exit 1; }
+            $WELCOME_MSG
+            export SSHHOME=\$(mktemp -d -t .$(whoami).sshrc.XXXX)
+            export SSHRCCLEANUP=\$SSHHOME
+            trap \"rm -rf \$SSHRCCLEANUP; exit\" 0
+            echo $'"$(cat "$0" | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d > \$SSHHOME/sshrc
+            chmod +x \$SSHHOME/sshrc
+
+            echo $'"$( cat << 'EOF' | openssl enc -base64
+                if [ -r /etc/profile ]; then source /etc/profile; fi
+                if [ -r ~/.bash_profile ]; then source ~/.bash_profile
+                elif [ -r ~/.bash_login ]; then source ~/.bash_login
+                elif [ -r ~/.profile ]; then source ~/.profile
+                fi
+                export PATH=$PATH:$SSHHOME
+                source $SSHHOME/.sshrc;
+EOF
+                )"' | tr -s ' ' $'\n' | openssl enc -base64 -d > \$SSHHOME/sshrc.bashrc
+
+            echo $'"$( cat << 'EOF' | openssl enc -base64
+#!/usr/bin/env bash
+                exec bash --rcfile <(echo '
+                [ -r /etc/profile ] && source /etc/profile
+                if [ -r ~/.bash_profile ]; then source ~/.bash_profile
+                elif [ -r ~/.bash_login ]; then source ~/.bash_login
+                elif [ -r ~/.profile ]; then source ~/.profile
+                fi
+                source '$SSHHOME'/.sshrc;
+                export PATH=$PATH:'$SSHHOME'
+                ') "$@"
+EOF
+                )"' | tr -s ' ' $'\n' | openssl enc -base64 -d > \$SSHHOME/bashsshrc
+            chmod +x \$SSHHOME/bashsshrc
+
+            echo $'"$(tar czf - -h -C $SSHHOME $files | openssl enc -base64)"' | tr -s ' ' $'\n' | openssl enc -base64 -d | tar mxzf - -C \$SSHHOME
+            export SSHHOME=\$SSHHOME
+            echo \"$CMDARG\" >> \$SSHHOME/sshrc.bashrc
+            bash --rcfile \$SSHHOME/sshrc.bashrc
+            "
+    else
+        echo "No such file: $SSHHOME/.sshrc" >&2
+        exit 1
+    fi
+}
+
+function sshrc_parse() {
+  while [[ -n $1 ]]; do
+    case $1 in
+      -b | -c | -D | -E | -e | -F | -I | -i | -J | -L | -l | -m | -O | -o | -p | -Q | -R | -S | -W | -w )
+        SSHARGS="$SSHARGS $1 $2"; shift ;;
+      -* )
+        SSHARGS="$SSHARGS $1" ;;
+      *)
+        if [ -z "$DOMAIN" ]; then
+         DOMAIN="$1"
+        else
+          local SEMICOLON=$([[ "$@" = *[![:space:]]* ]] && echo '; ')
+          CMDARG="$@$SEMICOLON exit"
+          return;
+        fi
+        ;;
+    esac
+    shift
+  done
+  if [ -z $DOMAIN ]; then
+    ssh $SSHARGS; exit 1;
+  fi
+}
+
+command -v openssl >/dev/null 2>&1 || { echo >&2 "sshrc requires openssl to be installed locally, but it's not. Aborting."; exit 1; }
+sshrc_parse "$@"
+sshrc

--- a/.local/share/chezmoi/dot_config/zsh/dot_zlogin
+++ b/.local/share/chezmoi/dot_config/zsh/dot_zlogin
@@ -1,0 +1,12 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+# Execute code that does not affect the current session in the background.
+{
+  # Compile the completion dump to increase startup speed.
+  zcompdump="${ZDOTDIR:-$HOME}/.zcompdump"
+  if [[ -s "$zcompdump" && (! -s "${zcompdump}.zwc" || "$zcompdump" -nt "${zcompdump}.zwc") ]]; then
+    zcompile "$zcompdump"
+  fi
+} &!

--- a/.local/share/chezmoi/dot_config/zsh/dot_zprofile
+++ b/.local/share/chezmoi/dot_config/zsh/dot_zprofile
@@ -1,0 +1,69 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+# Locale Settings
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8
+
+# NB: need to run `autoload zkbd && zkbd` to setup keycode file being sourced below
+# ideally, only need to run ^ once when setting up a new computer.
+# source ~/.zkbd/$TERM-${${DISPLAY:t}:-$VENDOR-$OSTYPE}
+
+# `less` configuration
+# -F: automatically exit if the entire file can be displayed on the first screen.
+# -X: disable termcap (de)/init. (stops less clearing the screen).
+# -R: color it up.
+# -j.5: make search results appear in the center of the screen (.5 = 50%).
+export LESS="-FXRj.5"
+export LESSCHARSET=utf-8
+export PAGER=less
+
+# EDITOR preferences
+export EDITOR="vim" # as god intended
+bindkey -v          # vim bindings for zsh
+
+# Export existing paths.
+typeset -gxU path PATH
+typeset -gxU fpath FPATH
+typeset -gxU manpath MANPATH
+
+# github base path (useful for `ghc`)
+export GHPATH=$HOME/code/gocode/src/github.com
+export DOTFILES=$HOME/dotfiles
+
+# Multiple installs of go using https://dave.cheney.net/2014/04/20/how-to-install-multiple-versions-of-go
+# GOBASE=/Users/rungta/code/go1.17.3/bin
+export GOPATH=$HOME/code/gocode
+
+# Enable XDG for `ghcup`, via https://www.haskell.org/ghcup/guide/
+export GHCUP_USE_XDG_DIRS=1
+
+# PATH(s), relies on zsh magic (path == $PATH but in array form and sync'd)
+path=(
+  $HOME/bin
+  $HOME/.local/bin
+  /opt/homebrew/{bin,sbin}
+  $GOPATH/bin
+  /opt/homebrew/opt/python@3.11/libexec/bin
+  $HOME/code/FlameGraph
+  $HOME/code/gocode/src/code.uber.internal/go-code/bin
+  $HOME/code/gocode/src/code.uber.internal/go-code/tools
+  $HOME/.cargo/bin
+  /usr/{sbin,bin}
+  /{sbin,bin}
+  /usr/local/{sbin,bin}
+  $path
+)
+path=($^path(N-/))
+
+# Set the list of directories that man searches for manuals.
+manpath=(
+  /usr/local/man
+  /usr/local/share/man
+  /usr/share/man
+)
+manpath=($^manpath(N-/))
+
+# Added by OrbStack: command-line tools and integration
+source ~/.orbstack/shell/init.zsh 2>/dev/null || :

--- a/.local/share/chezmoi/dot_config/zsh/dot_zshenv
+++ b/.local/share/chezmoi/dot_config/zsh/dot_zshenv
@@ -1,0 +1,17 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+# XDG Base Directory specification
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+
+# Set ZDOTDIR to use XDG_CONFIG_HOME
+export ZDOTDIR="${XDG_CONFIG_HOME}/zsh"
+
+# Ensure that a non-login, non-interactive shell has a defined environment.
+if [[ ( "$SHLVL" -eq 1 && ! -o LOGIN ) && -s "${ZDOTDIR}/.zprofile" ]]; then
+  source "${ZDOTDIR}/.zprofile"
+fi

--- a/.local/share/chezmoi/dot_config/zsh/dot_zshrc
+++ b/.local/share/chezmoi/dot_config/zsh/dot_zshrc
@@ -1,0 +1,38 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+export SYSTEM=$(uname -s)
+export ZSHCONFIG=$DOTFILES
+
+# Update to use XDG-compliant path for init.sh
+ZSH_INIT=${XDG_CONFIG_HOME}/zsh/init.sh
+if [[ -s ${ZSH_INIT} ]]; then
+    source ${ZSH_INIT}
+else
+    echo "Could not find the init script ${ZSH_INIT}"
+fi
+
+# Compinit optimization - only regenerate dump once per day
+# https://gist.github.com/ctechols/ca1035271ad134841284
+# https://carlosbecker.com/posts/speeding-up-zsh
+#
+# Note: This is now handled by zinit with zpcompinit in zinit-init.zsh
+# Commenting out to avoid duplicate initialization
+#
+# autoload -Uz compinit
+# case $SYSTEM in
+#   Darwin)
+#     if [ $(date +'%j') != $(/usr/bin/stat -f '%Sm' -t '%j' ${ZDOTDIR:-$HOME}/.zcompdump) ]; then
+#       compinit;
+#     else
+#       compinit -C;
+#     fi
+#     ;;
+#   Linux)
+#     # not yet match GNU & BSD stat
+#   ;;
+# esac
+
+# Added by Windsurf
+export PATH="/Users/prateek/.codeium/windsurf/bin:$PATH"

--- a/.local/share/chezmoi/dot_config/zsh/extra/fzf.zsh
+++ b/.local/share/chezmoi/dot_config/zsh/extra/fzf.zsh
@@ -1,0 +1,55 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+# make fzf ctrl-r behave like zaw, via https://github.com/fsouza/dotfiles/blob/main/extra/fzf
+function _rebind_ctrl-r {
+	function fzf-history-widget {
+		local selected num
+		setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases 2> /dev/null
+		selected=( $(fc -rl 1 | perl -ne 'print if !$seen{($_ =~ s/^\s*[0-9]+\s+//r)}++' |
+			FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} ${FZF_DEFAULT_OPTS} -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort --expect=ctrl-e $FZF_CTRL_R_OPTS --query=${(qqq)LBUFFER} +m" $(__fzfcmd)) )
+		local ret=$?
+		if [ -n "${selected}" ]; then
+			local accept=0
+			if [[ $selected[1] == ctrl-e ]]; then
+				accept=1
+				shift selected
+			fi
+			num=$selected[1]
+			if [ -n "${num}" ]; then
+				zle vi-fetch-history -n $num
+				[[ $accept = 0 ]] && zle accept-line
+			fi
+		fi
+		zle reset-prompt
+		return $ret
+	}
+	zle     -N   fzf-history-widget
+	bindkey '^R' fzf-history-widget
+}
+
+function _setup_fzf {
+	# ensure fzf completion and key-bindings is configured.
+	if [[ -v HOMEBREW_PREFIX ]] && [ -d ${HOMEBREW_PREFIX}/opt/fzf ]; then
+		[[ $- == *i* ]] && source ${HOMEBREW_PREFIX}/opt/fzf/shell/completion.zsh 2> /dev/null
+
+		# very opinionated FZF style opts.
+		export FZF_DEFAULT_OPTS="
+			--bind=ctrl-e:accept
+			--cycle
+			--height=40% --layout=reverse --border=none --info=hidden --margin=0% --marker='*' --history-size=${HISTSIZE}
+			--color=dark
+			--color=fg:-1,bg:-1,hl:#c678dd,fg+:#ffffff,bg+:#252931,hl+:#d858fe
+			--color=info:#98c379,prompt:#61afef,pointer:#be5046,marker:#e5c07b,spinner:#61afef,header:#61afef
+		"
+		export FZF_DEFAULT_COMMAND="fd --type f --hidden -E '.git' -E '.hg'"
+
+		source ${HOMEBREW_PREFIX}/opt/fzf/shell/key-bindings.zsh
+		_rebind_ctrl-r
+	fi
+}
+
+if command -v fzf &>/dev/null; then
+	_setup_fzf
+fi

--- a/.local/share/chezmoi/dot_config/zsh/init.sh
+++ b/.local/share/chezmoi/dot_config/zsh/init.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+#-----------------------------------------------------
+# Cache homebrew prefix early (before plugins need it)
+#-----------------------------------------------------
+if [[ -z ${HOMEBREW_PREFIX:-} ]] && command -v brew >/dev/null 2>&1; then
+    export HOMEBREW_PREFIX="$(brew --prefix)"
+fi
+
+#-----------------------------------------------------
+# bootstrap zinit script
+#-----------------------------------------------------
+ZINIT_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/zinit/zinit.git"
+if [[ ! -d "$ZINIT_HOME" ]]; then
+    mkdir -p "$(dirname $ZINIT_HOME)"
+    git clone https://github.com/zdharma-continuum/zinit.git "$ZINIT_HOME"
+fi
+source "$ZINIT_HOME/zinit.zsh"
+
+#-----------------------------------------------------
+# load zinit plugins
+#-----------------------------------------------------
+source "${XDG_CONFIG_HOME}/zsh/zinit-init.zsh"
+
+#-----------------------------------------------------
+# Setting autoloaded functions
+#-----------------------------------------------------
+zsh_fns=${XDG_CONFIG_HOME}/zsh/autoload
+fpath=($zsh_fns $fpath)
+if [[ -d "$zsh_fns" ]]; then
+    for func in $zsh_fns/*; do
+        autoload -Uz ${func:t}
+    done
+fi
+unset zsh_fns
+
+#-----------------------------------------------------
+# Load all utility scripts
+#-----------------------------------------------------
+zsh_libs=${XDG_CONFIG_HOME}/zsh/lib
+if [[ -d "$zsh_libs" ]]; then
+   for file in $zsh_libs/*.zsh; do
+      source $file
+   done
+fi
+unset zsh_libs
+
+#-----------------------------------------------------
+# Load all extras from ${XDG_CONFIG_HOME}/zsh/extra/*.zsh
+# NB: these are to be loaded after everything else,
+# as they overwrite behaviour of stuff.
+#-----------------------------------------------------
+extras=${XDG_CONFIG_HOME}/zsh/extra
+if [[ -d "$extras" ]]; then
+   for file in $extras/*.zsh; do
+      source $file
+   done
+fi
+unset extras
+
+# Set PATH for macOS (only for interactive login shells)
+if [[ -x /bin/launchctl && -o interactive && -o login ]]; then
+    /bin/launchctl setenv PATH "$PATH"
+fi

--- a/.local/share/chezmoi/dot_config/zsh/lib/alias.zsh
+++ b/.local/share/chezmoi/dot_config/zsh/lib/alias.zsh
@@ -1,0 +1,84 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+# git aliases
+alias gs='autoload_scmpuff_status'
+alias ga="git add"
+alias gd="git diff"
+alias gb="git branch"
+alias gca="git commit -a"
+alias gl="git gl"
+alias gco="git checkout"
+alias gp='git pull origin $(git rev-parse --abbrev-ref HEAD)'
+alias gpo='git pull origin $(git rev-parse --abbrev-ref HEAD)'
+alias push='git push origin $(git rev-parse --abbrev-ref HEAD)'
+alias pushf='git push origin $(git rev-parse --abbrev-ref HEAD) --force'
+alias pull='git pull'
+alias grim='git rebase -i $(git symbolic-ref refs/remotes/origin/HEAD | sed "s@^refs/remotes/origin/@@")'
+alias grimb='BASE=$(git symbolic-ref refs/remotes/origin/HEAD | sed "s@^refs/remotes/origin/@@") && git rebase -i $(git merge-base $BASE HEAD)'
+
+# use fzf to autocomplete git branches
+gcf() {
+    git checkout $(git branch | fzf)
+}
+
+# use fzf to delete branches, allow multiple selections
+gbd() {
+    # use TAB/S-TAB to select multiple branches
+    git branch -D $(git branch | fzf -m)
+}
+
+# adapted from https://github.com/Phantas0s/.dotfiles/blob/master/zsh/scripts_fzf.zsh
+# git log browser with FZF
+fgl() {
+  git log --graph --color=always \
+      --format="%C(auto)%h%d %s %C(black)%C(bold)%cr" "$@" |
+  fzf --ansi --no-sort --reverse --tiebreak=index --bind=ctrl-s:toggle-sort \
+      --bind "ctrl-m:execute:
+                (grep -o '[a-f0-9]\{7\}' | head -1 |
+                xargs -I % sh -c 'git show --color=always % | less -R') << 'FZF-EOF'
+                {}
+FZF-EOF"
+}
+
+# # adapted from: http://stackoverflow.com/questions/14031970/git-push-current-branch-shortcut
+# function gpb()
+# {
+#     if git rev-parse --abbrev-ref --symbolic-full-name @{u} > /dev/null 2>&1; then
+#         git push origin HEAD
+#     else
+#         git push -u origin HEAD
+#     fi
+# }
+
+alias jls="jira issue list"
+# FIXME: alias ssh=sshrc
+
+# Aliases
+alias ls='ls -G'
+alias ll='ls -lhG'
+alias vimd='vim -d'
+alias psef='ps -ef | grep -i'
+alias ps='ps -T'
+# alias cat='bat --style=plain'
+alias grep='egrep --color=auto'
+alias egrep='egrep --color=auto'
+
+## zshrc modification aliases
+alias sz='exec zsh'
+alias ez='code ~/dotfiles'
+alias jz='cd ~/dotfiles'
+
+alias ec='code ~/.claude'
+alias jc='cd ~/.claude'
+
+alias yo='open -a Yoink'
+alias yolo='claude --dangerously-skip-permissions'
+# FIXME: Pipe Aliases
+# alias L=' | less '
+# alias G=' | egrep --color=auto '
+# alias T=' | tail '
+# alias H=' | head '
+# alias W=' | wc -l '
+# alias S=' | sort '

--- a/.local/share/chezmoi/dot_config/zsh/lib/completions.zsh
+++ b/.local/share/chezmoi/dot_config/zsh/lib/completions.zsh
@@ -1,0 +1,50 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+################################################################################
+# https://github.com/sorin-ionescu/prezto/blob/master/modules/completion/init.zsh
+# https://github.com/robbyrussell/oh-my-zsh/blob/master/lib/completion.zsh
+# https://github.com/zimfw/zimfw/blob/master/modules/completion/init.zsh
+# https://grml.org/zsh/zsh-lovers.html
+################################################################################
+
+unsetopt menu_complete     # do not autoselect the first completion entry
+unsetopt flow_control      # disable start/stop characters in shell editor
+unsetopt case_glob         # makes globbing (filename generation) case-sensitive
+
+setopt no_beep             # no beeps
+setopt multios             # tee/cat automatically
+setopt always_to_end       # move cursor to the end of a completed word
+setopt auto_menu           # show completion menu on a successive tab press
+setopt complete_in_word    # complete from both ends of a word
+setopt no_complete_aliases # autoexapnd aliases
+setopt nolistambiguous     # one tab for completion
+
+# zsh completion
+zstyle ':completion:*' menu select
+compctl -g '*(/)' rmdir dircmp j
+compctl -g '*(-/)' cd chdir dirs pushd j
+
+## colorize completions
+zstyle ':completion:*' list-colors ''
+zstyle ':completion:*:default' list-colors ${(s.:.)LS_COLORS}
+
+# [ -f ~/.fzf-tab/fzf-tab.plugin.zsh ] && source ~/.fzf-tab/fzf-tab.plugin.zsh
+# zstyle ':fzf-tab:*' continuous-trigger '/'
+# zstyle ':fzf-tab:*' fzf-bindings 'ctrl-e:accept'
+# zstyle ':fzf-tab:*' accept-line enter
+
+# globalias() {
+#    if [[ $LBUFFER =~ ' [A-Z0-9]+$' ]]; then
+#      zle _expand_alias
+#      zle expand-word
+#    fi
+#    zle self-insert
+# }
+#
+# zle -N globalias
+#
+# bindkey " " globalias
+# bindkey "^ " magic-space           # control-space to bypass completion
+# bindkey -M isearch " " magic-space # normal space during searches

--- a/.local/share/chezmoi/dot_config/zsh/lib/dircolors-custom
+++ b/.local/share/chezmoi/dot_config/zsh/lib/dircolors-custom
@@ -1,0 +1,227 @@
+# vim: ft=dircolors:fdm=marker:et:sw=2:
+
+# See:
+#		https://unix.stackexchange.com/a/94306/27109
+#		"The format for 256 color escape codes is 38;5;colorN for foreground colors
+#   and 48;5;colorN for background colors."
+#
+#   https://github.com/trapd00r/LS_COLORS
+#		http://linux-sxs.org/housekeeping/lscolors.html
+#
+# Needs dircolors/gdircolors from GNU coreutils
+# brew info coreutils
+
+DIR 		01;34 					# directory
+LINK 		target
+SOCK 		01;35 					# socket
+MISSING 	00
+SETUID 		37;41
+SETGID 		30;43
+CAPABILITY 	30;41
+
+
+*README               38;5;220;1
+*README.rst           38;5;220;1
+*LICENSE              38;5;220;1
+*COPYING              38;5;220;1
+*INSTALL              38;5;220;1
+*COPYRIGHT            38;5;220;1
+*AUTHORS              38;5;220;1
+*HISTORY              38;5;220;1
+*CONTRIBUTORS         38;5;220;1
+*PATENTS              38;5;220;1
+*VERSION              38;5;220;1
+*NOTICE               38;5;220;1
+*CHANGES              38;5;220;1
+
+
+.log                  38;5;190
+.txt                  38;5;253
+
+# markup {{{2
+.info                 38;5;184
+.markdown             38;5;184
+.md                   38;5;184
+.mmd                  38;5;184
+
+# docs, images
+
+.chm                  38;5;151
+.djvu                 38;5;141
+.pdf                  38;5;141
+.PDF                  38;5;141
+.epub                 38;5;131
+.doc                  38;5;111
+.docx                 38;5;111
+.eps                  38;5;111
+.ps                   38;5;111
+.rtf                  38;5;111
+.pps                  38;5;166
+.ppt                  38;5;166
+.pptx                 38;5;166
+.xls                  38;5;112
+.xlsx                 38;5;112
+.xltx                 38;5;73
+.jpeg                 38;5;87
+.JPG                  38;5;87
+.jpg                  38;5;87
+
+
+# version control {{{2
+.git                  38;5;197
+.gitignore            38;5;240
+.gitattributes        38;5;240
+.gitmodules           38;5;240
+
+# shell {{{2
+.awk                  38;5;170
+.bash                 38;5;171
+.sh                   38;5;172
+.vim                  38;5;173
+*conf                 38;5;174
+*rc                   38;5;175
+.login                38;5;176
+.logout               38;5;177
+.zsh                  38;5;180
+
+
+# python
+.py                   38;5;41
+
+# perl
+.pl                   38;5;208
+.PL                   38;5;160
+
+# SQL
+.msql                 38;5;222
+.mysql                38;5;222
+.pgsql                38;5;222
+.sql                  38;5;222
+.sqlite               38;5;60
+
+# Python
+.py                   38;5;41
+.pyc                  38;5;240
+
+# Web
+.js                   38;5;074
+.css                  38;5;125
+.less                 38;5;125
+.sass                 38;5;125
+.scss                 38;5;125
+.htm                  38;5;125
+.html                 38;5;125
+.json                 38;5;178
+.xml                  38;5;178
+.yml                  38;5;178
+.php                  38;5;81
+.coffee               38;5;074
+.htaccess             38;5;230
+
+#   CakePHP view scripts and helpers
+.ctp                  38;5;81
+#   Twig template engine
+.twig                 38;5;81
+
+
+# JAVA
+.java                 38;5;074
+.jsp                  38;5;074
+
+# Build stuff {{{2
+*Dockerfile           38;5;155
+.dockerignore         38;5;240
+*Makefile             38;5;155
+*Makefile             38;5;155
+*MANIFEST             38;5;243
+
+  # packaged apps {{{2
+.apk                  38;5;215
+.jad                  38;5;215
+.jar                  38;5;215
+
+# partition images {{{2
+.dmg                  38;5;124
+.sparseimage          38;5;124
+.dmg                  38;5;215
+
+
+# state files
+.pid                  38;5;248
+.state                38;5;248
+*lockfile             38;5;248
+.lock                 38;5;241
+*composer.lock        38;5;96
+*lock.json            38;5;96
+*components*          38;5;241
+
+# state dumps
+.dump                 38;5;241
+.stackdump            38;5;241
+.zcompdump            38;5;241
+.zwc                  38;5;241
+
+# macOS
+.DS_Store             38;5;239
+.localized            38;5;239
+.CFUserTextEncoding   38;5;239
+
+.md5                  38;5;116
+.properties           38;5;116
+.torrent              38;5;116
+
+# RStudio project file
+.Rproj                38;5;11
+
+# archives {{{1
+.7z                   38;5;210
+.bz2                  38;5;210
+.gz                   38;5;210
+.lzma                 38;5;210
+.rar                  38;5;210
+.tar                  38;5;210
+.tgz                  38;5;210
+.zip                  38;5;210
+
+
+# 0 = default colour
+# 1 = bold
+# 4 = underlined
+# 5 = flashing text
+# 6 = no change
+# 7 = reverse field
+# 8 = black
+# 9 = strikethrough (cool!)
+# 10 - 29= no change
+# 30 = light green
+# 31 = red
+# 32 = green
+# 33 = orange
+# 34 = blue
+# 35 = purple
+# 36 = cyan
+# 37 = grey
+# 38 = underline
+# 39 = no change
+# 40 = black background
+# 41 = red background
+# 42 = green background
+# 43 = orange background
+# 44 = blue background
+# 45 = purple background
+# 46 = cyan background
+# 47 = grey background
+# 90 = dark grey
+# 91 = light red
+# 92 = light green
+# 93 = yellow
+# 94 = light blue
+# 95 = light purple
+# 96 = turquoise
+# 100 = dark grey background
+# 101 = light red background
+# 102 = light green background
+# 103 = yellow background
+# 104 = light blue background
+# 105 = light purple background
+# 106 = turquoise background

--- a/.local/share/chezmoi/dot_config/zsh/lib/fzf-tab.zsh
+++ b/.local/share/chezmoi/dot_config/zsh/lib/fzf-tab.zsh
@@ -1,0 +1,8 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+# Only use fzf when there are more than 10 candidates
+zstyle ':fzf-tab:*' fzf-min-height 10
+zstyle ':fzf-tab:complete:*' fzf-bindings 'tab:accept'
+zstyle ':fzf-tab:*' switch-group ',' '.'

--- a/.local/share/chezmoi/dot_config/zsh/lib/history.zsh
+++ b/.local/share/chezmoi/dot_config/zsh/lib/history.zsh
@@ -1,0 +1,20 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+# history options
+# nb: careful updating the history size - it gets expensive
+export HISTFILE=$HOME/.zhistory      # enable history saving on shell exit
+export HISTSIZE=30000                # lines of history to maintain memory
+export SAVEHIST=30000                # lines of history to maintain in history file.
+
+setopt EXTENDED_HISTORY			  # write in the ":start:elapsed;command" format
+setopt HIST_EXPIRE_DUPS_FIRST # allow dups, but expire old ones when I hit HISTSIZE
+setopt HIST_FIND_NO_DUPS      # do not find dups in history
+setopt HIST_IGNORE_ALL_DUPS   # Even if there are commands inbetween commands that are the same, still only save the last one
+setopt HIST_IGNORE_DUPS       # If I type cd and then cd again, only save the last one
+setopt HIST_IGNORE_SPACE      # If a line starts with a space, don't save it.
+setopt HIST_NO_STORE          # dont store invocations of history command.
+setopt HIST_REDUCE_BLANKS     # Pretty    Obvious.  Right?
+setopt HIST_SAVE_NO_DUPS      # dont save dupes
+setopt INC_APPEND_HISTORY     # Write after each command

--- a/.local/share/chezmoi/dot_config/zsh/lib/keybind.zsh
+++ b/.local/share/chezmoi/dot_config/zsh/lib/keybind.zsh
@@ -1,0 +1,55 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+# make key presses work a lot faster
+# `man keytimeout`: The time the shell waits, in hundredths of seconds,
+# for another key to be pressed when reading bound multi-character sequences.
+KEYTIMEOUT=1
+
+# Enable bracketed paste mode for better paste handling in vi-mode
+autoload -Uz bracketed-paste-magic
+zle -N bracketed-paste bracketed-paste-magic
+
+# Fix paste issues in vi-mode
+zstyle ':bracketed-paste-magic' active-widgets '.self-insert-unmeta'
+
+# map ctrl-space to accept auto-suggestions.
+# color map: https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg
+# usable attributes: https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting
+# export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=252,standout"
+# bindkey '^ ' autosuggest-accept # toggle on ctrl-space
+
+# Who doesn't want home and end to work?
+bindkey -M viins "${key[Home]}" beginning-of-line
+bindkey -M viins "${key[End]}" end-of-line
+
+# ensure alt+arrow keys work
+bindkey "^[^[[D" backward-word
+bindkey "^[^[[C" forward-word
+
+# copy buffer to stack and clear, reload it next time editor starts up
+bindkey -M vicmd 'q' push-line
+
+# vim editing for command line
+autoload -z edit-command-line
+zle -N edit-command-line
+bindkey -M vicmd 'v' edit-command-line
+
+# rerun last command & insert output into current buffer
+zmodload -i zsh/parameter
+insert-last-command-output() {
+  LBUFFER+="$(eval $history[$((HISTCMD-1))])"
+}
+zle -N insert-last-command-output
+bindkey -M viins "^P" insert-last-command-output
+
+# ctrl-u in vi-cmd mode invokes the url_select autoload function
+zle -N url_select
+bindkey -M vicmd "^u" url_select
+
+# TODO: rerurn last command and page output using the bat help pager
+# rerun-last-command-with-bat() {
+#   bathelp='bat --plain --language=help'
+#   $history[$((HISTCMD-1))]
+# }

--- a/.local/share/chezmoi/dot_config/zsh/lib/ls_color.zsh
+++ b/.local/share/chezmoi/dot_config/zsh/lib/ls_color.zsh
@@ -1,0 +1,10 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+#-----------------------------------------------------
+# Add colors to ls command
+#-----------------------------------------------------
+if [ -f "/usr/local/bin/gdircolors"  ] || [ -f "/usr/bin/gdircolors" ]; then
+	eval $( gdircolors -b ${ZSHCONFIG}/zsh/lib/dircolors-custom )
+fi

--- a/.local/share/chezmoi/dot_config/zsh/lib/prompt.zsh
+++ b/.local/share/chezmoi/dot_config/zsh/lib/prompt.zsh
@@ -1,0 +1,7 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+
+export PURE_PROMPT_SYMBOL="λ"
+export PURE_PROMPT_VICMD_SYMBOL="Λ"

--- a/.local/share/chezmoi/dot_config/zsh/lib/uber.zsh
+++ b/.local/share/chezmoi/dot_config/zsh/lib/uber.zsh
@@ -1,0 +1,84 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+export ST=$HOME/code/gocode/src/code.uber.internal/infra/statsdex
+
+alias prod='DOMAIN=system.uberinternal.com; PROD=https://ignored:$(usso -ussh $DOMAIN -print)@$DOMAIN'
+
+list_adhoc() {
+  lzc host list --group=m3-adhoc --format H
+}
+
+ssha() {
+  ssh $(list_adhoc | fzf)
+}
+
+# h/t https://stackoverflow.com/questions/75428312/custom-json-output-formatting-with-jq
+prettify_grafana_json() {
+   jq '.[].datapoints |= "<q>\(tojson)</q>"' | jq -Rr 'sub("<q>(?<s>.*)</q>"; .s)' --sort-keys
+}
+
+# example usage
+# $ resolve_uns uns://phx2/phx2-prod03/us1/statsdex_query/preprod/p-phx2/0:http
+resolve_uns() {
+  uns_path=$1
+  jump_host=$(list_adhoc | head -n 1)
+  ssh ${jump_host} "uns --format compact $uns_path"
+}
+
+# example_usage
+# $ setup_tunnel 8080 $(resolve_uns uns://phx2/phx2-prod03/us1/statsdex_query/preprod/p-phx2/0:http)
+setup_tunnel() {
+  local_port=$1
+  target_hostport=$2
+  jump_host=$(list_adhoc | head -n 1)
+  echo "setting up tunnel on localhost:$local_port to hit $target_hostport via $jump_host"
+  ssh -L ${local_port}:${target_hostport} -N $jump_host
+}
+
+function reposearch() {
+  echo "{\"constraints\": {\"query\": \"$1\"}}"     \
+    | arc call-conduit diffusion.repository.search \
+    | jq -r '.response.data[] | "\(.fields.name) - https://code.uberinternal.com/diffusion/\(.fields.callsign)"'
+}
+
+# functions to make working with arc suck less.
+## WIP quick git commit
+alias wip='git commit -am "fixup! WIP"'
+
+# return the name of the default branch
+function master_or_main() {
+	# via https://stackoverflow.com/questions/28666357/how-to-get-default-git-branch
+	git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
+}
+
+# merges all commits between master..HEAD into a single commit.
+function squash() {
+  GIT_SEQUENCE_EDITOR="sed -i -re '2,\$s/^pick /fixup /'" git rebase -i $(master_or_main)
+}
+
+# merges all commits between master..HEAD with a `fixup!` prefix into the preceding commit.
+function fixup() {
+  GIT_SEQUENCE_EDITOR="sed -i -re '/fixup!/s/^pick /fixup /'" git rebase -i $(master_or_main)
+}
+
+# extract_diff assumes a bunch of shit
+# requires that the differential revision be mentioned in the commit message of the first commit on the branch based off master
+# i.e. no chaining of diffs, no base branch which isn't master, etc.
+function extract_diff() {
+	local base=$(master_or_main)
+  git log --format='%B' -n1 $(git log ${base}..HEAD --oneline | tail -n1 | cut -d ' ' -f 1) | grep 'https://code.uberinternal.com' | sed -e 's@.*\(D[0-9][0-9]*\)$@\1@'
+}
+
+# au is only meant to be used during update, not for creation.
+function au() {
+	local base=$(master_or_main)
+  arc diff --update $(extract_diff) $(git merge-base ${base} HEAD) --message '.' $@
+}
+alias ws='wip && squash'
+alias wsa='wip && squash && au'
+alias wsp='wip && squash && push'
+
+alias wf='wip && fixup'
+alias wff='wip && fixup && farc upload master..'

--- a/.local/share/chezmoi/dot_config/zsh/zinit-init.zsh
+++ b/.local/share/chezmoi/dot_config/zsh/zinit-init.zsh
@@ -1,0 +1,45 @@
+#!/usr/bin/env zsh
+# vim:syntax=sh
+# vim:filetype=sh
+
+# https://zdharma-continuum.github.io/zinit/wiki/GALLERY/
+
+# Load critical items first (prompt needs to be immediate)
+# Load the pure theme, with zsh-async library that's bundled with it
+zinit ice pick"async.zsh" src"pure.zsh" lucid
+zinit light sindresorhus/pure
+
+# fzf is loaded via custom setup in zsh/extra/fzf.zsh
+# Installation handled by Brewfile during bootstrap (not zinit)
+# Removed zinit pack to avoid double loading
+
+# Defer non-critical plugins with turbo mode
+# wait - defers loading (in seconds or with special value)
+# lucid - skip "Loaded" message
+# atinit/atload - commands to run before/after loading
+
+# Completions must load first
+zinit ice wait lucid blockf atpull'zinit creinstall -q .'
+zinit light zsh-users/zsh-completions
+
+# fzf-tab loads after completions with compinit
+zinit ice wait lucid atinit"zpcompinit; zpcdreplay"
+zinit light Aloxaf/fzf-tab
+
+# Syntax highlighting loads last (no compinit needed)
+zinit ice wait lucid
+zinit light zdharma-continuum/fast-syntax-highlighting
+
+# Vi motions can be deferred
+zinit ice wait lucid
+zinit light zsh-vi-more/vi-motions
+
+# direnv loads from binary (deferred since not needed immediately)
+zinit ice wait"1" from"gh-r" as"program" mv"direnv* -> direnv"          \
+    atclone'./direnv hook zsh > zhook.zsh' atpull'%atclone' \
+    pick"direnv" src="zhook.zsh"
+zinit light direnv/direnv
+
+# # ex: commands in vi mode
+# zi ice wait"0" lucid
+# zinit light zsh-vi-more/ex-mode

--- a/.local/share/chezmoi/dot_inputrc
+++ b/.local/share/chezmoi/dot_inputrc
@@ -1,0 +1,2 @@
+# XDG Base Directory support - redirect to XDG location
+$include ~/.config/readline/inputrc

--- a/.local/share/chezmoi/dot_vimrc
+++ b/.local/share/chezmoi/dot_vimrc
@@ -1,0 +1,20 @@
+" XDG Base Directory support - redirect to XDG location
+set runtimepath^=$XDG_CONFIG_HOME/vim
+set runtimepath+=$XDG_DATA_HOME/vim
+set runtimepath+=$XDG_CONFIG_HOME/vim/after
+
+set packpath^=$XDG_DATA_HOME/vim,$XDG_CONFIG_HOME/vim
+set packpath+=$XDG_CONFIG_HOME/vim/after,$XDG_DATA_HOME/vim/after
+
+let g:netrw_home = $XDG_DATA_HOME."/vim"
+call mkdir($XDG_DATA_HOME."/vim/spell", 'p')
+
+set backupdir=$XDG_CACHE_HOME/vim/backup | call mkdir(&backupdir, 'p')
+set directory=$XDG_CACHE_HOME/vim/swap   | call mkdir(&directory, 'p')
+set undodir=$XDG_CACHE_HOME/vim/undo     | call mkdir(&undodir,   'p')
+set viewdir=$XDG_CACHE_HOME/vim/view     | call mkdir(&viewdir,   'p')
+
+if !has('nvim') | set viminfofile=$XDG_CACHE_HOME/vim/viminfo | endif
+
+" Source the actual vimrc from XDG location
+runtime vimrc

--- a/.local/share/chezmoi/dot_zshenv
+++ b/.local/share/chezmoi/dot_zshenv
@@ -1,0 +1,8 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+# This file redirects to the XDG-compliant location
+# Set ZDOTDIR before sourcing the actual .zshenv
+export ZDOTDIR="${XDG_CONFIG_HOME:-$HOME/.config}/zsh"
+[[ -f "$ZDOTDIR/.zshenv" ]] && source "$ZDOTDIR/.zshenv"

--- a/.vimrc
+++ b/.vimrc
@@ -1,0 +1,20 @@
+" XDG Base Directory support - redirect to XDG location
+set runtimepath^=$XDG_CONFIG_HOME/vim
+set runtimepath+=$XDG_DATA_HOME/vim
+set runtimepath+=$XDG_CONFIG_HOME/vim/after
+
+set packpath^=$XDG_DATA_HOME/vim,$XDG_CONFIG_HOME/vim
+set packpath+=$XDG_CONFIG_HOME/vim/after,$XDG_DATA_HOME/vim/after
+
+let g:netrw_home = $XDG_DATA_HOME."/vim"
+call mkdir($XDG_DATA_HOME."/vim/spell", 'p')
+
+set backupdir=$XDG_CACHE_HOME/vim/backup | call mkdir(&backupdir, 'p')
+set directory=$XDG_CACHE_HOME/vim/swap   | call mkdir(&directory, 'p')
+set undodir=$XDG_CACHE_HOME/vim/undo     | call mkdir(&undodir,   'p')
+set viewdir=$XDG_CACHE_HOME/vim/view     | call mkdir(&viewdir,   'p')
+
+if !has('nvim') | set viminfofile=$XDG_CACHE_HOME/vim/viminfo | endif
+
+" Source the actual vimrc from XDG location
+runtime vimrc

--- a/.zshenv
+++ b/.zshenv
@@ -1,0 +1,8 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+# This file redirects to the XDG-compliant location
+# Set ZDOTDIR before sourcing the actual .zshenv
+export ZDOTDIR="${XDG_CONFIG_HOME:-$HOME/.config}/zsh"
+[[ -f "$ZDOTDIR/.zshenv" ]] && source "$ZDOTDIR/.zshenv"

--- a/CHEZMOI_STRUCTURE.md
+++ b/CHEZMOI_STRUCTURE.md
@@ -1,0 +1,146 @@
+# Chezmoi Directory Structure
+
+This document explains how the dotfiles are structured for use with chezmoi.
+
+## Chezmoi Naming Conventions
+
+Chezmoi uses special naming conventions to handle dotfiles:
+
+- `dot_filename` → `.filename` (e.g., `dot_zshenv` → `.zshenv`)
+- `dot_config/` → `.config/` (directories with dots)
+- `private_filename` → `filename` (for files with secrets, encrypted)
+- `executable_filename` → `filename` (with executable permissions)
+
+## Current Structure
+
+```
+~/.local/share/chezmoi/
+├── dot_zshenv              → ~/.zshenv
+├── dot_vimrc               → ~/.vimrc
+├── dot_inputrc             → ~/.inputrc
+├── dot_config/             → ~/.config/
+│   ├── zsh/
+│   │   ├── dot_zshenv      → ~/.config/zsh/.zshenv
+│   │   ├── dot_zshrc       → ~/.config/zsh/.zshrc
+│   │   ├── dot_zprofile    → ~/.config/zsh/.zprofile
+│   │   ├── dot_zlogin      → ~/.config/zsh/.zlogin
+│   │   ├── init.sh
+│   │   ├── zinit-init.zsh
+│   │   ├── autoload/
+│   │   ├── lib/
+│   │   └── extra/
+│   ├── vim/
+│   │   ├── vimrc
+│   │   └── vimrc.orig
+│   ├── less/
+│   │   └── lesskey
+│   ├── readline/
+│   │   └── inputrc
+│   └── chezmoi/
+│       └── chezmoi.toml
+├── .chezmoiignore
+├── .gitignore
+└── README.md
+```
+
+## How Files Are Deployed
+
+When you run `chezmoi apply`, the following happens:
+
+1. **Root dotfiles**: Files like `dot_zshenv` are created as `.zshenv` in your home directory
+2. **Config directory**: The `dot_config/` directory is created as `~/.config/`
+3. **Nested dotfiles**: Files like `dot_config/zsh/dot_zshrc` become `~/.config/zsh/.zshrc`
+
+## Managing Files
+
+### Adding new files
+
+```bash
+# Add a single file
+chezmoi add ~/.gitconfig
+# Creates: ~/.local/share/chezmoi/dot_gitconfig
+
+# Add a config file
+chezmoi add ~/.config/git/config
+# Creates: ~/.local/share/chezmoi/dot_config/git/config
+```
+
+### Editing files
+
+```bash
+# Edit a managed file
+chezmoi edit ~/.zshenv
+# Or edit directly in the source
+chezmoi cd
+vim dot_zshenv
+```
+
+### Applying changes
+
+```bash
+# See what would change
+chezmoi diff
+
+# Apply all changes
+chezmoi apply
+
+# Apply a specific file
+chezmoi apply ~/.zshenv
+```
+
+## Templates
+
+Chezmoi supports templates for machine-specific configuration:
+
+```bash
+# Create a template file
+mv dot_gitconfig dot_gitconfig.tmpl
+
+# Use template variables
+# In dot_gitconfig.tmpl:
+[user]
+    name = {{ .name }}
+    email = {{ .email }}
+```
+
+## Encryption
+
+For sensitive files:
+
+```bash
+# Add an encrypted file
+chezmoi add --encrypt ~/.ssh/config
+# Creates: private_dot_ssh/private_config
+```
+
+## Best Practices
+
+1. **Use .chezmoiignore**: Exclude files that shouldn't be managed
+2. **Keep secrets encrypted**: Use `private_` prefix for sensitive files
+3. **Use templates**: For machine-specific configurations
+4. **Regular commits**: Treat the chezmoi source as a git repository
+5. **Test before applying**: Always run `chezmoi diff` first
+
+## Troubleshooting
+
+### File not updating
+```bash
+# Force re-apply
+chezmoi apply --force ~/.config/zsh/.zshrc
+```
+
+### Wrong permissions
+```bash
+# Make a script executable
+cd $(chezmoi source-path)
+mv script executable_script
+```
+
+### See managed files
+```bash
+# List all managed files
+chezmoi managed
+
+# List files that would be changed
+chezmoi status
+```

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,0 +1,223 @@
+# XDG Base Directory Migration Guide
+
+This guide documents the migration to XDG Base Directory specification and chezmoi integration.
+
+## Overview
+
+The dotfiles have been migrated to follow the XDG Base Directory specification:
+
+- **Configuration files**: `$XDG_CONFIG_HOME` (default: `~/.config/`)
+- **Data files**: `$XDG_DATA_HOME` (default: `~/.local/share/`)
+- **Cache files**: `$XDG_CACHE_HOME` (default: `~/.cache/`)
+- **State files**: `$XDG_STATE_HOME` (default: `~/.local/state/`)
+
+## What Changed
+
+### Directory Structure
+
+```
+Old Structure:
+~/
+├── .zshrc
+├── .zshenv
+├── .zprofile
+├── .zlogin
+├── .vimrc
+├── .inputrc
+├── .lesskey
+└── dotfiles/
+    ├── zsh/
+    ├── vimrc
+    └── ...
+
+New Structure:
+~/
+├── .zshenv (symlink for compatibility)
+├── .vimrc (symlink for compatibility)
+├── .inputrc (symlink for compatibility)
+└── .config/
+    ├── zsh/
+    │   ├── .zshenv
+    │   ├── .zshrc
+    │   ├── .zprofile
+    │   ├── .zlogin
+    │   ├── init.sh
+    │   ├── zinit-init.zsh
+    │   ├── autoload/
+    │   ├── lib/
+    │   └── extra/
+    ├── vim/
+    │   ├── vimrc
+    │   └── vimrc.orig
+    ├── less/
+    │   └── lesskey
+    ├── readline/
+    │   └── inputrc
+    └── chezmoi/
+        └── chezmoi.toml
+```
+
+### Key Changes
+
+1. **Zsh Configuration**:
+   - Main zsh configs moved to `~/.config/zsh/`
+   - `ZDOTDIR` is set to `$XDG_CONFIG_HOME/zsh`
+   - Zinit data moved to `~/.local/share/zinit/`
+   - `.zshenv` in home directory redirects to XDG location
+
+2. **Vim Configuration**:
+   - Config moved to `~/.config/vim/`
+   - Data/plugins stored in `~/.local/share/vim/`
+   - Cache files in `~/.cache/vim/`
+   - `.vimrc` in home directory sets up XDG paths
+
+3. **Other Configurations**:
+   - Less config: `~/.config/less/lesskey`
+   - Readline: `~/.config/readline/inputrc`
+   - Git config: `~/.config/git/config` (when migrated)
+
+## Migration Steps
+
+### 1. Backup Existing Configuration
+
+```bash
+# Create a backup of your current dotfiles
+cp -r ~/dotfiles ~/dotfiles.backup
+cp ~/.zsh* ~/.vim* ~/.inputrc ~/.lesskey ~/dotfiles.backup/
+```
+
+### 2. Run the Migration
+
+```bash
+# Clone or update the repository
+cd ~/dotfiles
+
+# Run the XDG-compliant bootstrap
+./bootstrap-xdg.sh
+
+# Install chezmoi
+./install-chezmoi.sh
+
+# Initialize chezmoi with your dotfiles
+./init-chezmoi.sh
+```
+
+### 3. Verify the Migration
+
+```bash
+# Check that configs are loaded correctly
+echo $ZDOTDIR  # Should show ~/.config/zsh
+echo $XDG_CONFIG_HOME  # Should show ~/.config
+
+# Test zsh
+zsh -c 'echo "Zsh works!"'
+
+# Test vim
+vim -c 'echo "Vim works!" | q'
+```
+
+## Using Chezmoi
+
+### Basic Commands
+
+```bash
+# See what files are managed
+chezmoi managed
+
+# See what would change
+chezmoi diff
+
+# Apply changes
+chezmoi apply
+
+# Add a new file
+chezmoi add ~/.config/new-app/config
+
+# Edit a managed file
+chezmoi edit ~/.config/zsh/.zshrc
+
+# Update from the source directory
+chezmoi update
+```
+
+### Setting Up Git Repository
+
+```bash
+cd ~/.local/share/chezmoi
+git init
+git add .
+git commit -m "Initial commit with XDG migration"
+git remote add origin https://github.com/yourusername/dotfiles.git
+git push -u origin main
+```
+
+### Installing on a New Machine
+
+```bash
+# Install chezmoi and apply dotfiles in one command
+sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply yourusername
+
+# Or step by step:
+# 1. Install chezmoi
+sh -c "$(curl -fsLS get.chezmoi.io)"
+
+# 2. Initialize from your repo
+chezmoi init https://github.com/yourusername/dotfiles.git
+
+# 3. See what would be changed
+chezmoi diff
+
+# 4. Apply the changes
+chezmoi apply
+```
+
+## Troubleshooting
+
+### Zsh not finding config
+
+If zsh doesn't load your config:
+1. Ensure `~/.zshenv` exists and contains the ZDOTDIR export
+2. Check that `~/.config/zsh/.zshenv` exists
+3. Try sourcing manually: `source ~/.zshenv`
+
+### Vim not finding config
+
+If vim doesn't load your config:
+1. Ensure `~/.vimrc` exists and sets XDG paths
+2. Check vim's runtimepath: `:set runtimepath?`
+3. Verify directories exist: `ls -la ~/.config/vim ~/.local/share/vim`
+
+### Permission Issues
+
+```bash
+# Fix permissions on config directories
+chmod -R 755 ~/.config
+chmod -R 755 ~/.local/share/chezmoi
+```
+
+## Benefits of This Setup
+
+1. **Cleaner Home Directory**: Fewer dotfiles cluttering `~/`
+2. **Better Organization**: Configs grouped by application
+3. **Easier Backups**: All configs in standard locations
+4. **Chezmoi Management**: Version control and templating
+5. **Portability**: Easy to replicate on new machines
+
+## Rollback
+
+If you need to rollback:
+
+```bash
+# Restore from backup
+cp -r ~/dotfiles.backup/.zsh* ~/
+cp -r ~/dotfiles.backup/.vim* ~/
+cp ~/dotfiles.backup/.inputrc ~/
+cp ~/dotfiles.backup/.lesskey ~/
+
+# Remove XDG directories
+rm -rf ~/.config/zsh ~/.config/vim ~/.config/less ~/.config/readline
+
+# Remove chezmoi
+chezmoi purge
+rm -rf ~/.local/share/chezmoi
+```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cd ~/dotfiles
 
 # Install and initialize chezmoi
 ./install-chezmoi.sh
-./init-chezmoi.sh
+./init-chezmoi-v2.sh  # Use v2 for proper dot_ structure
 ```
 
 ## Directory Structure

--- a/README.md
+++ b/README.md
@@ -1,2 +1,109 @@
-# Dotfiles Repo
-My dotfiles
+# dots - XDG-Compliant Dotfiles with Chezmoi
+
+> Personal dotfiles following XDG Base Directory specification and managed with chezmoi
+
+My dotfiles, now fully compliant with the XDG Base Directory specification and managed using [chezmoi](https://www.chezmoi.io/) for easy deployment and version control.
+
+## Features
+
+- ✅ **XDG Base Directory Compliant**: Clean home directory with configs in `~/.config/`
+- 🚀 **Chezmoi Integration**: Easy dotfile management and deployment
+- 🔧 **Zsh with Zinit**: Fast, modular shell configuration
+- 📝 **Vim Configuration**: Optimized vim setup with plugin management
+- 🖥️ **macOS Optimized**: Homebrew integration and macOS-specific settings
+- 🔄 **Backward Compatible**: Symlinks for apps that don't support XDG
+
+## Quick Start
+
+### New Installation
+
+```bash
+# Install chezmoi and apply dotfiles in one command
+sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply <your-github-username>
+```
+
+### Manual Installation
+
+```bash
+# Clone this repository
+git clone https://github.com/<your-username>/dotfiles.git ~/dotfiles
+cd ~/dotfiles
+
+# Run the XDG-compliant bootstrap
+./bootstrap-xdg.sh
+
+# Install and initialize chezmoi
+./install-chezmoi.sh
+./init-chezmoi.sh
+```
+
+## Directory Structure
+
+```
+~/.config/
+├── zsh/          # Zsh configuration
+├── vim/          # Vim configuration  
+├── less/         # Less pager config
+├── readline/     # Readline config
+└── chezmoi/      # Chezmoi config
+
+~/.local/share/
+├── zinit/        # Zsh plugin manager
+├── vim/          # Vim plugins and data
+└── chezmoi/      # Chezmoi source directory
+```
+
+## Migration Guide
+
+If you're migrating from the old dotfile structure, see [MIGRATION_GUIDE.md](MIGRATION_GUIDE.md) for detailed instructions.
+
+## Key Components
+
+### Zsh Configuration
+- Plugin management with [zinit](https://github.com/zdharma-continuum/zinit)
+- Custom prompt and completions
+- Extensive aliases and functions
+- XDG-compliant with `ZDOTDIR` set to `~/.config/zsh`
+
+### Vim Configuration
+- Plugin management with [vim-plug](https://github.com/junegunn/vim-plug)
+- XDG paths for config, data, and cache
+- Sensible defaults and key mappings
+
+### Chezmoi Integration
+- Manages all dotfiles in `~/.local/share/chezmoi`
+- Easy updates with `chezmoi update`
+- Template support for machine-specific configs
+
+## Customization
+
+1. Edit chezmoi-managed files:
+   ```bash
+   chezmoi edit ~/.config/zsh/.zshrc
+   ```
+
+2. Apply changes:
+   ```bash
+   chezmoi apply
+   ```
+
+3. Commit changes:
+   ```bash
+   chezmoi cd
+   git add .
+   git commit -m "Your changes"
+   git push
+   ```
+
+## Original Structure
+
+The original (non-XDG) dotfiles structure is preserved in the git history. Key files have been migrated as follows:
+
+- `.zshrc` → `.config/zsh/.zshrc`
+- `.vimrc` → `.config/vim/vimrc`
+- `.inputrc` → `.config/readline/inputrc`
+- `lesskey` → `.config/less/lesskey`
+
+## License
+
+MIT

--- a/SETUP_SUMMARY.md
+++ b/SETUP_SUMMARY.md
@@ -1,0 +1,129 @@
+# Setup Summary: XDG-Compliant Dotfiles with Chezmoi
+
+## What We've Done
+
+1. **Migrated to XDG Base Directory Specification**
+   - Configuration files moved to `~/.config/`
+   - Data files use `~/.local/share/`
+   - Cache files use `~/.cache/`
+
+2. **Created Proper Chezmoi Structure**
+   - Files with dots use `dot_` prefix (e.g., `dot_zshenv` → `.zshenv`)
+   - Config directory is `dot_config/` → `.config/`
+   - Nested dotfiles properly named (e.g., `dot_config/zsh/dot_zshrc` → `.config/zsh/.zshrc`)
+
+3. **Maintained Backward Compatibility**
+   - `.zshenv` in home directory sets ZDOTDIR and sources XDG location
+   - `.vimrc` in home directory configures XDG paths
+   - `.inputrc` includes XDG config file
+
+## File Structure
+
+### Chezmoi Source Directory (`~/.local/share/chezmoi/`)
+```
+.
+├── dot_zshenv              # → ~/.zshenv
+├── dot_vimrc               # → ~/.vimrc
+├── dot_inputrc             # → ~/.inputrc
+├── dot_config/             # → ~/.config/
+│   ├── zsh/
+│   │   ├── dot_zshenv      # → ~/.config/zsh/.zshenv
+│   │   ├── dot_zshrc       # → ~/.config/zsh/.zshrc
+│   │   ├── dot_zprofile    # → ~/.config/zsh/.zprofile
+│   │   ├── dot_zlogin      # → ~/.config/zsh/.zlogin
+│   │   └── ...            # Other zsh config files
+│   ├── vim/               # Vim configuration
+│   ├── less/              # Less configuration
+│   ├── readline/          # Readline configuration
+│   └── chezmoi/           # Chezmoi configuration
+├── .chezmoiignore         # Files to ignore
+├── .gitignore             # Git ignore file
+└── README.md              # Documentation
+```
+
+### Deployed Structure (`~/`)
+```
+~/
+├── .zshenv                 # Sets ZDOTDIR, sources XDG config
+├── .vimrc                  # Sets XDG paths for vim
+├── .inputrc                # Includes XDG readline config
+└── .config/
+    ├── zsh/               # All zsh configuration
+    ├── vim/               # Vim configuration
+    ├── less/              # Less configuration
+    ├── readline/          # Readline configuration
+    └── chezmoi/           # Chezmoi configuration
+```
+
+## Quick Start Commands
+
+```bash
+# 1. Install chezmoi (if not installed)
+./install-chezmoi.sh
+
+# 2. Initialize chezmoi with proper structure
+./init-chezmoi-v2.sh
+
+# 3. Preview what would be applied
+chezmoi diff
+
+# 4. Apply the configuration
+chezmoi apply
+
+# 5. Set up git repository
+cd ~/.local/share/chezmoi
+git init
+git add .
+git commit -m "Initial commit: XDG-compliant dotfiles with chezmoi"
+```
+
+## Daily Usage
+
+```bash
+# Edit a file
+chezmoi edit ~/.config/zsh/dot_zshrc
+
+# Add a new file
+chezmoi add ~/.config/newapp/config
+
+# See what changed
+chezmoi diff
+
+# Apply changes
+chezmoi apply
+
+# Push to git
+chezmoi cd
+git add .
+git commit -m "Update configuration"
+git push
+```
+
+## Benefits
+
+1. **Clean Home Directory**: Only 3 compatibility files in `~/`
+2. **Proper Organization**: All configs in standard XDG locations
+3. **Version Control**: Easy to manage with git through chezmoi
+4. **Portability**: Deploy anywhere with one command
+5. **Flexibility**: Templates and encryption support for different machines
+
+## Next Steps
+
+1. Test the setup with `./test-xdg-migration.sh`
+2. Initialize chezmoi with `./init-chezmoi-v2.sh`
+3. Create a GitHub repository for your chezmoi source
+4. Push your dotfiles to GitHub
+5. Test deployment on another machine
+
+## Troubleshooting
+
+If something doesn't work:
+
+1. Check file permissions: `ls -la ~/.local/share/chezmoi/`
+2. Verify chezmoi status: `chezmoi status`
+3. See managed files: `chezmoi managed`
+4. Force re-apply: `chezmoi apply --force`
+
+For more details, see:
+- [MIGRATION_GUIDE.md](MIGRATION_GUIDE.md) - Detailed migration instructions
+- [CHEZMOI_STRUCTURE.md](CHEZMOI_STRUCTURE.md) - Chezmoi file structure explanation

--- a/bootstrap-xdg.sh
+++ b/bootstrap-xdg.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env zsh
+# vim:syntax=zsh
+# vim:filetype=zsh
+
+set -eo pipefail
+
+CWD=$(dirname -- "$( readlink -f -- "$0"; )")
+
+# install homebrew
+if ! command -v brew &> /dev/null
+then
+  echo "install homebrew please"
+  exit 1
+fi
+
+# install homebrew files
+# brew bundle install --file $CWD/Brewfile
+
+# XDG Base Directory setup
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+export XDG_STATE_HOME="${XDG_STATE_HOME:-$HOME/.local/state}"
+
+# Create XDG directories
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME"
+
+# setup symlinks for backward compatibility
+if [ ! -f $HOME/.zshenv ]; then ln -s $CWD/.zshenv $HOME/.zshenv ; fi
+if [ ! -f $HOME/.vimrc ]; then ln -s $CWD/.vimrc $HOME/.vimrc ; fi
+if [ ! -f $HOME/.inputrc ]; then ln -s $CWD/.inputrc $HOME/.inputrc ; fi
+
+# Copy config files to XDG locations
+if [ ! -d "$XDG_CONFIG_HOME/zsh" ]; then
+  cp -r "$CWD/.config/zsh" "$XDG_CONFIG_HOME/"
+fi
+
+if [ ! -d "$XDG_CONFIG_HOME/vim" ]; then
+  cp -r "$CWD/.config/vim" "$XDG_CONFIG_HOME/"
+fi
+
+if [ ! -d "$XDG_CONFIG_HOME/less" ]; then
+  cp -r "$CWD/.config/less" "$XDG_CONFIG_HOME/"
+fi
+
+if [ ! -d "$XDG_CONFIG_HOME/readline" ]; then
+  cp -r "$CWD/.config/readline" "$XDG_CONFIG_HOME/"
+fi
+
+# .claude directory symlinks
+mkdir -p $HOME/.claude
+for dir in agents commands docs; do
+  if [ -d "$CWD/.claude/$dir" ]; then
+    if [ -e "$HOME/.claude/$dir" ]; then
+      rm -rf "$HOME/.claude/$dir"
+    fi
+    ln -sf "$CWD/.claude/$dir" "$HOME/.claude/$dir"
+  fi
+done
+
+# directories
+mkdir -p $HOME/code
+mkdir -p $HOME/.sshrc.d
+
+# generate lesskey binary file for older versions of less that might be
+# present on remote machines.
+# nb: will need to `brew install less` for the following line to work.
+lesskey -o $XDG_DATA_HOME/less $XDG_CONFIG_HOME/less/lesskey
+cp $XDG_DATA_HOME/less $HOME/.sshrc.d/.less
+
+# zsh setup with XDG compliance
+# nb: this setup takes _heavy_ inspiration from the work of https://github.com/htr3n/zsh-config
+ZINIT_HOME="${XDG_DATA_HOME}/zinit/zinit.git"
+if [ ! -d "$ZINIT_HOME" ]; then
+  mkdir -p "$(dirname $ZINIT_HOME)"
+  git clone https://github.com/zdharma-continuum/zinit.git "$ZINIT_HOME"
+fi
+
+# vim setup with XDG compliance
+mkdir -p "$XDG_DATA_HOME/vim/autoload"
+curl -fLo "$XDG_DATA_HOME/vim/autoload/plug.vim" --create-dirs \
+     https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+vim -c "PlugInstall"
+
+# Create cache directories for vim
+mkdir -p "$XDG_CACHE_HOME/vim/"{backup,swap,undo,view}
+
+# osx install
+## dropbox
+### TODO: ensure files are available offline
+## alfred
+### TODO: sync preferences to dropbox folder
+### TODO: command+space to alfred, not spotlight (disable via Settings -> Keyboard)
+## moom
+defaults import com.manytricks.Moom $CWD/osx-apps/Moom.plist
+### TODO: open the license file from 1p
+## osx
+### dock settings (left, hiding)
+### add bluetooth/wifi/sounds to menu bar, remove spotlight
+### set alert volume to 0 (in Settings -> Sounds)
+
+
+# TODO: pending automation items
+# - [ ] need to run `autoload zkbd && zkbd` to setup keycode file (used in zshrc)
+# - [ ] need to copy and sync $HOME/.config directory too (incl bootstrap.sh wiring)
+# - [ ] create ~/bin folder (both pulling that stuff into `dotfiles`, and hooking up to bootstrap)
+# - [ ] wire up boostrap.sh =>> scripts/build.sh
+# - [ ] ~/.gitconfig wiring
+#  - `git config --global --type=bool checkout.guess false`: https://gist.github.com/mmrko/b3ec6da9bea172cdb6bd83bdf95ee817 for git completions to not suck
+# - [X] ZDOTDIR and XDG_CONFIG_HOME=~/.config -- https://thevaluable.dev/zsh-install-configure-mouseless/ has ideas
+# - [ ] osx settings
+#  - VSCodeVim: `defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false` via https://github.com/VSCodeVim/Vim#mac

--- a/init-chezmoi-v2.sh
+++ b/init-chezmoi-v2.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Initialize chezmoi with proper XDG-compliant dotfiles structure
+
+set -e
+
+# Ensure chezmoi is installed
+if ! command -v chezmoi &> /dev/null; then
+    echo "chezmoi is not installed. Please run ./install-chezmoi.sh first"
+    exit 1
+fi
+
+# Set XDG directories
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+
+echo "Initializing chezmoi repository..."
+
+# Check if we're setting up from the workspace or need to create fresh
+if [ -d "/workspace/.local/share/chezmoi" ]; then
+    echo "Using prepared chezmoi source directory..."
+    
+    # If chezmoi is already initialized, back it up
+    if [ -d "$HOME/.local/share/chezmoi" ] && [ "$HOME" != "/workspace" ]; then
+        echo "Backing up existing chezmoi directory..."
+        mv "$HOME/.local/share/chezmoi" "$HOME/.local/share/chezmoi.backup.$(date +%Y%m%d_%H%M%S)"
+    fi
+    
+    # Copy the prepared chezmoi source
+    cp -r /workspace/.local/share/chezmoi "$HOME/.local/share/"
+    
+    echo "Chezmoi source directory prepared successfully!"
+else
+    echo "Setting up chezmoi from current dotfiles..."
+    
+    # Initialize chezmoi (this creates ~/.local/share/chezmoi)
+    chezmoi init --apply=false
+    
+    # Now we need to properly structure the files in chezmoi source
+    CHEZMOI_SOURCE="$HOME/.local/share/chezmoi"
+    
+    # Create dot files in chezmoi source
+    cp "$HOME/.zshenv" "$CHEZMOI_SOURCE/dot_zshenv" 2>/dev/null || true
+    cp "$HOME/.vimrc" "$CHEZMOI_SOURCE/dot_vimrc" 2>/dev/null || true
+    cp "$HOME/.inputrc" "$CHEZMOI_SOURCE/dot_inputrc" 2>/dev/null || true
+    
+    # Create dot_config directory structure
+    mkdir -p "$CHEZMOI_SOURCE/dot_config"
+    
+    # Copy config directories
+    for dir in zsh vim less readline chezmoi; do
+        if [ -d "$XDG_CONFIG_HOME/$dir" ]; then
+            cp -r "$XDG_CONFIG_HOME/$dir" "$CHEZMOI_SOURCE/dot_config/"
+            
+            # Rename any dotfiles in the zsh directory
+            if [ "$dir" = "zsh" ] && [ -d "$CHEZMOI_SOURCE/dot_config/zsh" ]; then
+                cd "$CHEZMOI_SOURCE/dot_config/zsh"
+                for f in .z*; do
+                    [ -f "$f" ] && mv "$f" "dot_${f#.}"
+                done
+                cd - >/dev/null
+            fi
+        fi
+    done
+    
+    # Copy .chezmoiignore if it exists
+    if [ -f "/workspace/.local/share/chezmoi/.chezmoiignore" ]; then
+        cp "/workspace/.local/share/chezmoi/.chezmoiignore" "$CHEZMOI_SOURCE/"
+    fi
+fi
+
+# Create a README for the chezmoi repository
+cat > "$HOME/.local/share/chezmoi/README.md" << 'EOF'
+# Dotfiles managed by chezmoi
+
+This repository contains my personal dotfiles managed by [chezmoi](https://www.chezmoi.io/).
+
+## Structure
+
+The dotfiles follow the XDG Base Directory specification with chezmoi naming conventions:
+
+- `dot_*` files become `.*` in the home directory
+- `dot_config/` becomes `~/.config/`
+- Configuration files are organized by application
+
+## Installation
+
+```bash
+# Install chezmoi
+sh -c "$(curl -fsLS get.chezmoi.io)"
+
+# Initialize chezmoi with this repo
+chezmoi init <your-github-username>
+
+# Preview changes
+chezmoi diff
+
+# Apply the dotfiles
+chezmoi apply
+```
+
+## Directory Structure
+
+```
+~/
+├── .zshenv         (from dot_zshenv)
+├── .vimrc          (from dot_vimrc)
+├── .inputrc        (from dot_inputrc)
+└── .config/        (from dot_config/)
+    ├── zsh/
+    ├── vim/
+    ├── less/
+    ├── readline/
+    └── chezmoi/
+```
+
+## Key Features
+
+- XDG Base Directory compliant
+- Zsh configuration with zinit plugin manager
+- Vim configuration with vim-plug
+- Less and readline configurations
+- Backward compatibility symlinks for applications that don't support XDG
+
+## Managing Dotfiles
+
+```bash
+# See what files are managed
+chezmoi managed
+
+# Add a new file
+chezmoi add ~/.config/newapp/config
+
+# Edit a managed file
+chezmoi edit ~/.config/zsh/dot_zshrc
+
+# Apply changes after editing
+chezmoi apply
+
+# Update from git repository
+chezmoi update
+```
+EOF
+
+echo ""
+echo "Chezmoi initialization complete!"
+echo ""
+echo "Next steps:"
+echo "1. Review the source files: ls -la ~/.local/share/chezmoi/"
+echo "2. See what would be applied: chezmoi diff"
+echo "3. Apply the dotfiles: chezmoi apply"
+echo "4. Set up a git repository:"
+echo "   cd ~/.local/share/chezmoi"
+echo "   git init"
+echo "   git add ."
+echo "   git commit -m 'Initial commit with XDG-compliant dotfiles'"
+echo "   git remote add origin <your-repo-url>"
+echo "   git push -u origin main"

--- a/init-chezmoi.sh
+++ b/init-chezmoi.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Initialize chezmoi with XDG-compliant dotfiles
+
+set -e
+
+# Ensure chezmoi is installed
+if ! command -v chezmoi &> /dev/null; then
+    echo "chezmoi is not installed. Please run ./install-chezmoi.sh first"
+    exit 1
+fi
+
+# Set XDG directories
+export XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+
+echo "Initializing chezmoi repository..."
+
+# Initialize chezmoi (this creates ~/.local/share/chezmoi)
+chezmoi init
+
+# Add configuration files to chezmoi
+echo "Adding dotfiles to chezmoi..."
+
+# Add XDG config files
+chezmoi add "$XDG_CONFIG_HOME/zsh"
+chezmoi add "$XDG_CONFIG_HOME/vim"
+chezmoi add "$XDG_CONFIG_HOME/less"
+chezmoi add "$XDG_CONFIG_HOME/readline"
+chezmoi add "$XDG_CONFIG_HOME/chezmoi/chezmoi.toml"
+
+# Add compatibility symlinks
+chezmoi add ~/.zshenv
+chezmoi add ~/.vimrc
+chezmoi add ~/.inputrc
+
+# Add other important files
+if [ -f ~/.gitconfig ]; then
+    chezmoi add ~/.gitconfig
+fi
+
+# Create a template for the README
+cat > "$HOME/.local/share/chezmoi/README.md" << 'EOF'
+# Dotfiles managed by chezmoi
+
+This repository contains my personal dotfiles managed by [chezmoi](https://www.chezmoi.io/).
+
+## Structure
+
+The dotfiles follow the XDG Base Directory specification:
+
+- Configuration files: `~/.config/`
+- Data files: `~/.local/share/`
+- Cache files: `~/.cache/`
+
+## Installation
+
+```bash
+# Install chezmoi
+sh -c "$(curl -fsLS get.chezmoi.io)"
+
+# Initialize chezmoi with this repo
+chezmoi init <your-github-username>
+
+# Apply the dotfiles
+chezmoi apply
+```
+
+## Key Features
+
+- XDG Base Directory compliant
+- Zsh configuration with zinit plugin manager
+- Vim configuration with vim-plug
+- Less and readline configurations
+- Backward compatibility symlinks for applications that don't support XDG
+
+## Files and Directories
+
+- `.config/zsh/` - Zsh configuration
+- `.config/vim/` - Vim configuration
+- `.config/less/` - Less pager configuration
+- `.config/readline/` - Readline configuration
+- `.zshenv` - Symlink for backward compatibility
+- `.vimrc` - Symlink for backward compatibility
+- `.inputrc` - Symlink for backward compatibility
+EOF
+
+echo "Chezmoi initialization complete!"
+echo ""
+echo "Next steps:"
+echo "1. Review the managed files: chezmoi managed"
+echo "2. See what changes would be made: chezmoi diff"
+echo "3. Apply changes: chezmoi apply"
+echo "4. Set up a git repository:"
+echo "   cd ~/.local/share/chezmoi"
+echo "   git init"
+echo "   git add ."
+echo "   git commit -m 'Initial commit'"
+echo "   git remote add origin <your-repo-url>"
+echo "   git push -u origin main"

--- a/install-chezmoi.sh
+++ b/install-chezmoi.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Install chezmoi
+
+set -e
+
+# Check if chezmoi is already installed
+if command -v chezmoi &> /dev/null; then
+    echo "chezmoi is already installed"
+    chezmoi --version
+else
+    echo "Installing chezmoi..."
+    
+    # Install chezmoi via the official install script
+    sh -c "$(curl -fsLS get.chezmoi.io)" -- -b $HOME/.local/bin
+    
+    # Add to PATH if not already there
+    if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+        echo "Adding $HOME/.local/bin to PATH"
+        export PATH="$HOME/.local/bin:$PATH"
+    fi
+fi
+
+echo "chezmoi installed successfully!"

--- a/test-xdg-migration.sh
+++ b/test-xdg-migration.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Test script to verify XDG migration
+
+set -e
+
+echo "=== XDG Migration Test ==="
+echo
+
+# Colors for output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Test function
+test_result() {
+    if [ $1 -eq 0 ]; then
+        echo -e "${GREEN}✓${NC} $2"
+    else
+        echo -e "${RED}✗${NC} $2"
+        EXIT_CODE=1
+    fi
+}
+
+EXIT_CODE=0
+
+echo "1. Checking XDG directories..."
+test_result $([ -d "$HOME/.config" ] && echo 0 || echo 1) "~/.config exists"
+test_result $([ -d "$HOME/.local/share" ] && echo 0 || echo 1) "~/.local/share exists"
+test_result $([ -d "$HOME/.cache" ] && echo 0 || echo 1) "~/.cache exists"
+
+echo
+echo "2. Checking Zsh configuration..."
+test_result $([ -f "$HOME/.zshenv" ] && echo 0 || echo 1) "~/.zshenv exists (compatibility)"
+test_result $([ -d "$HOME/.config/zsh" ] && echo 0 || echo 1) "~/.config/zsh directory exists"
+test_result $([ -f "$HOME/.config/zsh/.zshenv" ] && echo 0 || echo 1) "~/.config/zsh/.zshenv exists"
+test_result $([ -f "$HOME/.config/zsh/.zshrc" ] && echo 0 || echo 1) "~/.config/zsh/.zshrc exists"
+test_result $([ -f "$HOME/.config/zsh/.zprofile" ] && echo 0 || echo 1) "~/.config/zsh/.zprofile exists"
+
+echo
+echo "3. Checking Vim configuration..."
+test_result $([ -f "$HOME/.vimrc" ] && echo 0 || echo 1) "~/.vimrc exists (compatibility)"
+test_result $([ -d "$HOME/.config/vim" ] && echo 0 || echo 1) "~/.config/vim directory exists"
+test_result $([ -f "$HOME/.config/vim/vimrc" ] && echo 0 || echo 1) "~/.config/vim/vimrc exists"
+
+echo
+echo "4. Checking other configurations..."
+test_result $([ -f "$HOME/.inputrc" ] && echo 0 || echo 1) "~/.inputrc exists (compatibility)"
+test_result $([ -f "$HOME/.config/readline/inputrc" ] && echo 0 || echo 1) "~/.config/readline/inputrc exists"
+test_result $([ -f "$HOME/.config/less/lesskey" ] && echo 0 || echo 1) "~/.config/less/lesskey exists"
+
+echo
+echo "5. Checking environment variables in zsh..."
+if command -v zsh &> /dev/null; then
+    ZDOTDIR_CHECK=$(zsh -c 'echo $ZDOTDIR' 2>/dev/null)
+    test_result $([ "$ZDOTDIR_CHECK" = "$HOME/.config/zsh" ] && echo 0 || echo 1) "ZDOTDIR is set correctly"
+    
+    XDG_CONFIG_CHECK=$(zsh -c 'echo $XDG_CONFIG_HOME' 2>/dev/null)
+    test_result $([ -n "$XDG_CONFIG_CHECK" ] && echo 0 || echo 1) "XDG_CONFIG_HOME is set"
+else
+    echo -e "${YELLOW}⚠${NC}  zsh not found, skipping environment tests"
+fi
+
+echo
+echo "6. Checking Chezmoi setup..."
+test_result $([ -f "$HOME/.config/chezmoi/chezmoi.toml" ] && echo 0 || echo 1) "Chezmoi config exists"
+test_result $([ -f "$HOME/dotfiles/install-chezmoi.sh" ] && echo 0 || echo 1) "Chezmoi install script exists"
+test_result $([ -f "$HOME/dotfiles/init-chezmoi.sh" ] && echo 0 || echo 1) "Chezmoi init script exists"
+
+echo
+echo "7. File content verification..."
+if [ -f "$HOME/.zshenv" ]; then
+    if grep -q "ZDOTDIR" "$HOME/.zshenv"; then
+        test_result 0 ".zshenv sets ZDOTDIR"
+    else
+        test_result 1 ".zshenv sets ZDOTDIR"
+    fi
+fi
+
+if [ -f "$HOME/.vimrc" ]; then
+    if grep -q "XDG_CONFIG_HOME" "$HOME/.vimrc"; then
+        test_result 0 ".vimrc uses XDG paths"
+    else
+        test_result 1 ".vimrc uses XDG paths"
+    fi
+fi
+
+echo
+echo "=== Test Summary ==="
+if [ $EXIT_CODE -eq 0 ]; then
+    echo -e "${GREEN}All tests passed!${NC}"
+    echo "Your dotfiles have been successfully migrated to XDG Base Directory specification."
+else
+    echo -e "${RED}Some tests failed.${NC}"
+    echo "Please check the failed items above."
+fi
+
+echo
+echo "Next steps:"
+echo "1. Run './install-chezmoi.sh' to install chezmoi"
+echo "2. Run './init-chezmoi.sh' to initialize chezmoi with your dotfiles"
+echo "3. Restart your shell or run 'source ~/.zshenv' to apply changes"
+
+exit $EXIT_CODE


### PR DESCRIPTION
Migrate dotfiles to XDG Base Directory specification and integrate Chezmoi to improve organization, simplify backups, and enable robust dotfile management.

---
<a href="https://cursor.com/background-agent?bcId=bc-8cc06054-3b89-4465-b283-28a71827f88a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8cc06054-3b89-4465-b283-28a71827f88a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

